### PR TITLE
[FE][M2] 설정 페이지 & 임베딩 미리보기 (테마/언어, svg 미리보기)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.3",
-    "@radix-ui/react-tabs": "^1.1.3",
+    "@radix-ui/react-progress": "^1.1.7",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.3",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.89.0",
     "@tanstack/react-query-devtools": "^5.90.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.3
         version: 1.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.7
+        version: 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
@@ -490,6 +496,21 @@ packages:
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/react-dom@2.1.6':
+    resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -587,8 +608,24 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
@@ -687,6 +724,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -726,8 +776,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -805,6 +881,49 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.19':
     resolution: {integrity: sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==}
@@ -2932,6 +3051,23 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -3021,7 +3157,18 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -3112,6 +3259,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3141,6 +3306,16 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3154,6 +3329,35 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.1(@types/react@19.1.8)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
@@ -3214,6 +3418,37 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.19': {}
 

--- a/src/entities/dashboard/model/types.ts
+++ b/src/entities/dashboard/model/types.ts
@@ -1,6 +1,7 @@
 import type { DungeonAction } from "@/entities/dungeon-log/model/types";
 
-export type EquipmentSlot = "helmet" | "armor" | "weapon" | "ring";
+export const EQUIPMENT_SLOTS = ["helmet", "armor", "weapon", "ring"];
+export type EquipmentSlot = (typeof EQUIPMENT_SLOTS)[number];
 
 export type EquipmentRarity =
   | "common"

--- a/src/entities/inventory/ui/equipment-slot-grid.tsx
+++ b/src/entities/inventory/ui/equipment-slot-grid.tsx
@@ -1,0 +1,93 @@
+import { Fragment, useMemo, type ReactNode } from "react";
+import type {
+  InventoryEquippedMap,
+  InventoryItem,
+} from "@/entities/inventory/model/types";
+import {
+  EQUIPMENT_SLOTS,
+  type EquipmentSlot,
+} from "@/entities/dashboard/model/types";
+import { InventoryItemCard } from "@/entities/inventory/ui/inventory-item-card";
+import { getInventorySlotLabel } from "@/entities/inventory/config/slot-labels";
+
+interface EquipmentSlotGridProps {
+  equipped: InventoryEquippedMap | InventoryItem[];
+  className?: string;
+  renderSlot?: (
+    slot: EquipmentSlot,
+    item: InventoryItem | null,
+    content: ReactNode
+  ) => ReactNode;
+}
+
+export function EquipmentSlotGrid({
+  equipped,
+  className,
+  renderSlot,
+}: EquipmentSlotGridProps) {
+  const resolved = useMemo(() => {
+    return Array.isArray(equipped) ? mapFromItems(equipped) : equipped;
+  }, [equipped]);
+
+  return (
+    <div className={className}>
+      <div className="grid grid-cols-2 gap-3">
+        {EQUIPMENT_SLOTS.map((slot) => {
+          const item = resolved[slot] ?? null;
+          const baseContent = (
+            <div className="border-border bg-background flex h-auto w-full flex-col items-center justify-center gap-2 rounded-lg border p-3 text-center">
+              {item ? (
+                <InventoryItemCard
+                  item={item}
+                  className="items-center"
+                  showSlotLabel
+                />
+              ) : (
+                <InventoryEmptySlot slot={slot} />
+              )}
+            </div>
+          );
+
+          if (renderSlot) {
+            return (
+              <Fragment key={slot}>
+                {renderSlot(slot, item, baseContent)}
+              </Fragment>
+            );
+          }
+
+          return <Fragment key={slot}>{baseContent}</Fragment>;
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function InventoryEmptySlot({ slot }: { slot: EquipmentSlot }) {
+  return (
+    <div className="flex w-full flex-col items-center gap-2 text-center">
+      <div className="border-border flex size-14 items-center justify-center rounded-md border border-dashed" />
+      <div className="space-y-1">
+        <p className="text-xs font-semibold tracking-wide">
+          {getInventorySlotLabel(slot)}
+        </p>
+        <p className="text-muted-foreground text-[11px]">장비 없음</p>
+      </div>
+    </div>
+  );
+}
+
+function mapFromItems(items: InventoryItem[]) {
+  return EQUIPMENT_SLOTS.reduce<Record<EquipmentSlot, InventoryItem | null>>(
+    (acc, slot) => {
+      acc[slot] = items.find((item) => item.slot === slot) ?? null;
+      return acc;
+    },
+    {
+      helmet: null,
+      armor: null,
+      weapon: null,
+      ring: null,
+    }
+  );
+}

--- a/src/entities/settings/api/get-settings.ts
+++ b/src/entities/settings/api/get-settings.ts
@@ -1,0 +1,14 @@
+import { httpGet } from "@/shared/api/http-client";
+import { SETTINGS_ENDPOINTS } from "@/shared/config/env";
+import type {
+  SettingsData,
+  SettingsResponse,
+} from "@/entities/settings/model/types";
+
+export async function getSettings(): Promise<SettingsData> {
+  const response = await httpGet<SettingsResponse>(SETTINGS_ENDPOINTS.profile, {
+    parseAs: "json",
+  });
+
+  return response.settings;
+}

--- a/src/entities/settings/model/settings-query.ts
+++ b/src/entities/settings/model/settings-query.ts
@@ -1,0 +1,10 @@
+import { queryOptions } from "@tanstack/react-query";
+import { getSettings } from "@/entities/settings/api/get-settings";
+
+export const SETTINGS_QUERY_KEY = ["settings", "profile"] as const;
+
+export const settingsQueryOptions = queryOptions({
+  queryKey: SETTINGS_QUERY_KEY,
+  queryFn: getSettings,
+  staleTime: 1000 * 60 * 2,
+});

--- a/src/entities/settings/model/types.ts
+++ b/src/entities/settings/model/types.ts
@@ -1,0 +1,89 @@
+import type { AuthSession } from "@/entities/auth/model/types";
+import type {
+  EquipmentModifier,
+  EquipmentRarity,
+  EquipmentSlot,
+} from "@/entities/dashboard/model/types";
+import type { InventoryItemEffect } from "@/entities/inventory/model/types";
+export type {
+  LanguagePreference,
+  ThemePreference,
+} from "@/shared/lib/preferences/types";
+
+export interface SettingsProfile extends AuthSession {
+  email?: string;
+  joinedAt?: string;
+  lastLoginAt?: string;
+}
+
+export interface SettingsConnections {
+  github?: {
+    connected: boolean;
+    lastSyncAt?: string;
+    profileUrl?: string;
+  };
+}
+
+export interface SettingsData {
+  profile: SettingsProfile;
+  connections: SettingsConnections;
+}
+
+export interface SettingsResponse {
+  settings: SettingsData;
+}
+
+export type EmbeddingSize = "compact" | "square" | "wide";
+
+export interface EmbeddingStatBlock {
+  hp: {
+    current: number;
+    max: number;
+    equipmentBonus?: number;
+  };
+  atk: {
+    total: number;
+    equipmentBonus?: number;
+  };
+  def: {
+    total: number;
+    equipmentBonus?: number;
+  };
+  luck: {
+    total: number;
+    equipmentBonus?: number;
+  };
+  ap: {
+    total: number;
+    equipmentBonus?: number;
+  };
+}
+
+export interface EmbeddingEquipment {
+  id: string;
+  name: string;
+  slot: EquipmentSlot;
+  rarity: EquipmentRarity;
+  modifiers: EquipmentModifier[];
+  effect?: InventoryItemEffect | null;
+  sprite: string;
+}
+
+export interface EmbeddingPreview {
+  userId: string;
+  size: EmbeddingSize;
+  level: number;
+  exp: number;
+  expToLevel: number;
+  gold: number;
+  bestFloor: number;
+  currentFloor: number;
+  floorProgress: number;
+  stats: EmbeddingStatBlock;
+  equipment: EmbeddingEquipment[];
+  generatedAt: string;
+}
+
+export interface EmbeddingPreviewResponse {
+  preview: EmbeddingPreview;
+}

--- a/src/entities/settings/model/use-settings.ts
+++ b/src/entities/settings/model/use-settings.ts
@@ -1,0 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import { settingsQueryOptions } from "@/entities/settings/model/settings-query";
+
+export function useSettings() {
+  return useQuery(settingsQueryOptions);
+}

--- a/src/features/auth/logout/model/use-logout.ts
+++ b/src/features/auth/logout/model/use-logout.ts
@@ -1,0 +1,23 @@
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
+import { httpRequest } from "@/shared/api/http-client";
+import { AUTH_ENDPOINTS } from "@/shared/config/env";
+
+async function logoutRequest() {
+  await httpRequest<{ success: boolean }>(AUTH_ENDPOINTS.logout, {
+    method: "POST",
+    parseAs: "json",
+  });
+}
+
+export function useLogout() {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: logoutRequest,
+    onSuccess: async () => {
+      await router.options.context.auth.invalidateSession();
+      await router.navigate({ to: "/login" });
+    },
+  });
+}

--- a/src/features/character-summary/lib/build-character-overview.ts
+++ b/src/features/character-summary/lib/build-character-overview.ts
@@ -33,6 +33,7 @@ export interface CharacterOverview {
   exp: number;
   expToLevel: number;
   gold: number;
+  ap: number;
   floor: {
     current: number;
     best: number;
@@ -65,6 +66,7 @@ export function buildCharacterOverview(
     exp: state.exp,
     expToLevel: state.expToLevel,
     gold: state.gold,
+    ap: state.ap,
     floor: {
       current: state.floor,
       best: state.maxFloor,

--- a/src/features/character-summary/lib/build-character-overview.ts
+++ b/src/features/character-summary/lib/build-character-overview.ts
@@ -1,0 +1,156 @@
+import type { DashboardState } from "@/entities/dashboard/model/types";
+import type {
+  InventoryItem,
+  InventoryResponse,
+} from "@/entities/inventory/model/types";
+
+export interface CharacterStatValues {
+  hp: number;
+  maxHp: number;
+  atk: number;
+  def: number;
+  luck: number;
+  ap: number;
+}
+
+export interface CharacterStatModifier {
+  hp: number;
+  maxHp: number;
+  atk: number;
+  def: number;
+  luck: number;
+  ap: number;
+}
+
+export interface CharacterStatSummary {
+  total: CharacterStatValues;
+  base: CharacterStatValues;
+  equipmentBonus: CharacterStatModifier;
+}
+
+export interface CharacterOverview {
+  level: number;
+  exp: number;
+  expToLevel: number;
+  gold: number;
+  floor: {
+    current: number;
+    best: number;
+    progress: number;
+  };
+  stats: CharacterStatSummary;
+  equipment: InventoryItem[];
+}
+
+const DEFAULT_MODIFIER: CharacterStatModifier = {
+  hp: 0,
+  maxHp: 0,
+  atk: 0,
+  def: 0,
+  luck: 0,
+  ap: 0,
+};
+
+export function buildCharacterOverview(
+  state: DashboardState,
+  inventory: InventoryResponse
+): CharacterOverview {
+  const equippedItems = extractEquippedItems(inventory);
+  const equipmentBonus = calculateEquipmentBonus(equippedItems);
+  const totalStats = extractTotalStats(state);
+  const baseStats = calculateBaseStats(totalStats, equipmentBonus);
+
+  return {
+    level: state.level,
+    exp: state.exp,
+    expToLevel: state.expToLevel,
+    gold: state.gold,
+    floor: {
+      current: state.floor,
+      best: state.maxFloor,
+      progress: state.floorProgress,
+    },
+    stats: {
+      total: totalStats,
+      base: baseStats,
+      equipmentBonus,
+    },
+    equipment: equippedItems,
+  };
+}
+
+function extractEquippedItems(inventory: InventoryResponse): InventoryItem[] {
+  return (Object.values(inventory.equipped) as Array<InventoryItem | null>)
+    .filter(Boolean)
+    .map((item) => ({ ...item!, isEquipped: true }));
+}
+
+function extractTotalStats(state: DashboardState): CharacterStatValues {
+  return {
+    hp: state.hp,
+    maxHp: state.maxHp,
+    atk: state.atk,
+    def: state.def,
+    luck: state.luck,
+    ap: state.ap,
+  };
+}
+
+function calculateEquipmentBonus(
+  items: InventoryItem[]
+): CharacterStatModifier {
+  if (items.length === 0) {
+    return { ...DEFAULT_MODIFIER };
+  }
+
+  return items.reduce<CharacterStatModifier>(
+    (acc, item) => {
+      item.modifiers.forEach((modifier) => {
+        switch (modifier.stat) {
+          case "hp":
+            acc.hp += modifier.value;
+            acc.maxHp += modifier.value;
+            break;
+          case "atk":
+            acc.atk += modifier.value;
+            break;
+          case "def":
+            acc.def += modifier.value;
+            break;
+          case "luck":
+            acc.luck += modifier.value;
+            break;
+          case "ap":
+            acc.ap += modifier.value;
+            break;
+          default:
+            break;
+        }
+      });
+      return acc;
+    },
+    { ...DEFAULT_MODIFIER }
+  );
+}
+
+function calculateBaseStats(
+  total: CharacterStatValues,
+  equipment: CharacterStatModifier
+): CharacterStatValues {
+  return {
+    hp: clampStat(total.hp - equipment.hp, total.hp),
+    maxHp: clampStat(total.maxHp - equipment.maxHp, total.maxHp),
+    atk: clampStat(total.atk - equipment.atk, total.atk),
+    def: clampStat(total.def - equipment.def, total.def),
+    luck: clampStat(total.luck - equipment.luck, total.luck),
+    ap: clampStat(total.ap - equipment.ap, total.ap),
+  };
+}
+
+function clampStat(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(0, value);
+}

--- a/src/features/character-summary/model/use-character-overview.ts
+++ b/src/features/character-summary/model/use-character-overview.ts
@@ -1,0 +1,48 @@
+import { useCallback, useMemo } from "react";
+import { useDashboardState } from "@/entities/dashboard/model/use-dashboard-state";
+import { useInventory } from "@/entities/inventory/model/use-inventory";
+import {
+  buildCharacterOverview,
+  type CharacterOverview,
+} from "@/features/character-summary/lib/build-character-overview";
+
+export interface UseCharacterOverviewResult {
+  data: CharacterOverview | null;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => Promise<void>;
+  dashboard: ReturnType<typeof useDashboardState>;
+  inventory: ReturnType<typeof useInventory>;
+}
+
+export function useCharacterOverview(): UseCharacterOverviewResult {
+  const dashboard = useDashboardState();
+  const inventory = useInventory();
+
+  const data = useMemo(() => {
+    if (!dashboard.data || !inventory.data) {
+      return null;
+    }
+
+    return buildCharacterOverview(dashboard.data.state, inventory.data);
+  }, [dashboard.data, inventory.data]);
+
+  const isLoading = dashboard.isLoading || inventory.isLoading;
+  const isFetching = dashboard.isFetching || inventory.isFetching;
+  const isError = Boolean(dashboard.error || inventory.error);
+
+  const refetch = useCallback(async () => {
+    await Promise.all([dashboard.refetch(), inventory.refetch()]);
+  }, [dashboard, inventory]);
+
+  return {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+    refetch,
+    dashboard,
+    inventory,
+  };
+}

--- a/src/features/character-summary/ui/character-overview-header.tsx
+++ b/src/features/character-summary/ui/character-overview-header.tsx
@@ -1,0 +1,57 @@
+import { SummaryTile } from "@/shared/ui/summary-tile";
+import { formatNumber } from "@/entities/dashboard/lib/formatters";
+import { Progress } from "@/shared/ui/progress";
+
+interface CharacterOverviewHeaderProps {
+  level: number;
+  exp: number;
+  expToLevel: number;
+  floor: {
+    current: number;
+    best: number;
+    progress: number;
+  };
+  gold: number;
+  ap: number;
+}
+
+export function CharacterOverviewHeader({
+  level,
+  exp,
+  expToLevel,
+  floor,
+  gold,
+  ap,
+}: CharacterOverviewHeaderProps) {
+  const expPercent = resolvePercent(exp, expToLevel);
+  const floorPercent = resolvePercent(floor.progress, 100);
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-4">
+      <SummaryTile title="레벨" value={`Lv. ${level}`}>
+        <p className="text-muted-foreground text-xs">
+          {formatNumber(exp)} / {formatNumber(expToLevel)}
+        </p>
+        <Progress value={expPercent} aria-label="경험치 진행률" />
+      </SummaryTile>
+      <SummaryTile title="층 진행" value={`${floor.current}F / ${floor.best}F`}>
+        <p className="text-muted-foreground text-xs">진행도 {floorPercent}%</p>
+        <Progress value={floorPercent} aria-label="층 진행도" />
+      </SummaryTile>
+      <SummaryTile title="골드" value={`${formatNumber(gold)} G`}>
+        <p className="text-muted-foreground text-xs">총 보유 골드</p>
+      </SummaryTile>
+      <SummaryTile title="AP" value={`${formatNumber(ap)}`}>
+        <p className="text-muted-foreground text-xs">행동력</p>
+      </SummaryTile>
+    </div>
+  );
+}
+
+function resolvePercent(value: number, max: number): number {
+  if (max <= 0) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, Math.round((value / max) * 100)));
+}

--- a/src/features/character-summary/ui/character-stat-grid.tsx
+++ b/src/features/character-summary/ui/character-stat-grid.tsx
@@ -1,0 +1,60 @@
+import { StatItem } from "@/entities/inventory/ui/stat-item";
+import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
+import { formatNumber } from "@/entities/dashboard/lib/formatters";
+
+interface CharacterStatGridProps {
+  stats: CharacterStatSummary;
+  className?: string;
+}
+
+export function CharacterStatGrid({
+  stats,
+  className,
+}: CharacterStatGridProps) {
+  const entries = [
+    {
+      key: "hp",
+      title: "HP",
+      caption: `최대 HP ${formatNumber(stats.total.maxHp)}`,
+      total: stats.total.hp,
+      bonus: stats.equipmentBonus.hp,
+    },
+    {
+      key: "atk",
+      title: "ATK",
+      caption: "공격력",
+      total: stats.total.atk,
+      bonus: stats.equipmentBonus.atk,
+    },
+    {
+      key: "def",
+      title: "DEF",
+      caption: "방어력",
+      total: stats.total.def,
+      bonus: stats.equipmentBonus.def,
+    },
+    {
+      key: "luck",
+      title: "LUCK",
+      caption: "행운",
+      total: stats.total.luck,
+      bonus: stats.equipmentBonus.luck,
+    },
+  ];
+
+  return (
+    <div className={className}>
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {entries.map((entry) => (
+          <StatItem
+            key={entry.key}
+            title={entry.title}
+            caption={entry.caption}
+            total={entry.total}
+            equipmentBonus={entry.bonus}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/settings/model/use-language-preference.ts
+++ b/src/features/settings/model/use-language-preference.ts
@@ -1,0 +1,24 @@
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  getLanguagePreference,
+  setLanguagePreference,
+  subscribeLanguagePreference,
+} from "@/shared/lib/preferences/preferences";
+import type { LanguagePreference } from "@/shared/lib/preferences/types";
+
+export function useLanguagePreference() {
+  const language = useSyncExternalStore(
+    subscribeLanguagePreference,
+    getLanguagePreference,
+    getLanguagePreference
+  );
+
+  const setLanguage = useCallback((next: LanguagePreference) => {
+    setLanguagePreference(next);
+  }, []);
+
+  return {
+    language,
+    setLanguage,
+  } as const;
+}

--- a/src/features/settings/model/use-settings-preferences.ts
+++ b/src/features/settings/model/use-settings-preferences.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import { useLanguagePreference } from "@/features/settings/model/use-language-preference";
+import { useThemePreference } from "@/features/settings/model/use-theme-preference";
+
+export function useSettingsPreferences() {
+  const { theme, setTheme } = useThemePreference();
+  const { language, setLanguage } = useLanguagePreference();
+
+  return useMemo(
+    () => ({
+      theme,
+      setTheme,
+      language,
+      setLanguage,
+    }),
+    [language, setLanguage, setTheme, theme]
+  );
+}

--- a/src/features/settings/model/use-theme-preference.ts
+++ b/src/features/settings/model/use-theme-preference.ts
@@ -1,0 +1,24 @@
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  getThemePreference,
+  setThemePreference,
+  subscribeThemePreference,
+} from "@/shared/lib/preferences/preferences";
+import type { ThemePreference } from "@/shared/lib/preferences/types";
+
+export function useThemePreference() {
+  const theme = useSyncExternalStore(
+    subscribeThemePreference,
+    getThemePreference,
+    getThemePreference
+  );
+
+  const setTheme = useCallback((next: ThemePreference) => {
+    setThemePreference(next);
+  }, []);
+
+  return {
+    theme,
+    setTheme,
+  } as const;
+}

--- a/src/features/settings/ui/github-connection.tsx
+++ b/src/features/settings/ui/github-connection.tsx
@@ -1,0 +1,44 @@
+import { ExternalLink } from "lucide-react";
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/utils";
+import type { SettingsConnections } from "@/entities/settings/model/types";
+
+interface GithubConnectionProps {
+  connections: SettingsConnections;
+}
+
+export function GithubConnection({ connections }: GithubConnectionProps) {
+  const github = connections.github;
+
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <div className="flex w-full items-center justify-between gap-4">
+        <div>
+          <p className="text-foreground text-sm font-semibold">GitHub 연동</p>
+        </div>
+        <Badge
+          variant={github?.connected ? "secondary" : "outline"}
+          className={cn(
+            "text-xs",
+            github?.connected ? "bg-emerald-500/10 text-emerald-600" : undefined
+          )}
+        >
+          {github?.connected ? "연결됨" : "미연결"}
+        </Badge>
+      </div>
+      {github?.profileUrl ? (
+        <Button variant="outline" size="sm" className="gap-2" asChild>
+          <a href={github.profileUrl} target="_blank" rel="noreferrer">
+            GitHub 프로필 열기
+            <ExternalLink className="size-3.5" aria-hidden />
+          </a>
+        </Button>
+      ) : (
+        <Button variant="outline" size="sm" disabled>
+          연동 정보가 없습니다
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/features/settings/ui/preferences-form.tsx
+++ b/src/features/settings/ui/preferences-form.tsx
@@ -1,0 +1,88 @@
+import type {
+  LanguagePreference,
+  ThemePreference,
+} from "@/shared/lib/preferences/types";
+import {
+  LANGUAGE_PREFERENCE_VALUES,
+  THEME_PREFERENCE_VALUES,
+} from "@/shared/lib/preferences/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
+
+const THEME_LABEL_MAP: Record<ThemePreference, string> = {
+  system: "시스템 기본값",
+  light: "라이트",
+  dark: "다크",
+};
+
+const LANGUAGE_LABEL_MAP: Record<LanguagePreference, string> = {
+  ko: "한국어",
+  en: "English",
+};
+
+interface PreferencesFormProps {
+  theme: ThemePreference;
+  language: LanguagePreference;
+  onThemeChange: (preference: ThemePreference) => void;
+  onLanguageChange: (preference: LanguagePreference) => void;
+}
+
+export function PreferencesForm({
+  theme,
+  language,
+  onThemeChange,
+  onLanguageChange,
+}: PreferencesFormProps) {
+  return (
+    <div className="space-y-6">
+      <Fieldset label="테마">
+        <Select value={theme} onValueChange={onThemeChange}>
+          <SelectTrigger id="settings-theme">
+            <SelectValue placeholder="테마를 선택하세요" />
+          </SelectTrigger>
+          <SelectContent>
+            {THEME_PREFERENCE_VALUES.map((preference) => (
+              <SelectItem key={preference} value={preference}>
+                {THEME_LABEL_MAP[preference]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Fieldset>
+
+      <Fieldset label="언어">
+        <Select value={language} onValueChange={onLanguageChange}>
+          <SelectTrigger id="settings-language">
+            <SelectValue placeholder="언어를 선택하세요" />
+          </SelectTrigger>
+          <SelectContent>
+            {LANGUAGE_PREFERENCE_VALUES.map((preference) => (
+              <SelectItem key={preference} value={preference}>
+                {LANGUAGE_LABEL_MAP[preference]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Fieldset>
+    </div>
+  );
+}
+
+interface FieldsetProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function Fieldset({ label, children }: FieldsetProps) {
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <label className="text-foreground text-sm font-medium">{label}</label>
+      {children}
+    </fieldset>
+  );
+}

--- a/src/features/settings/ui/profile-field-list.tsx
+++ b/src/features/settings/ui/profile-field-list.tsx
@@ -1,0 +1,20 @@
+interface ProfileFieldListProps {
+  fields: Array<{ label: string; value: string }>;
+}
+
+export function ProfileFieldList({ fields }: ProfileFieldListProps) {
+  return (
+    <dl className="grid gap-4 text-sm sm:grid-cols-2">
+      {fields.map((field) => (
+        <div key={field.label} className="space-y-1">
+          <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            {field.label}
+          </dt>
+          <dd className="text-foreground text-sm font-semibold break-words">
+            {field.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/features/settings/ui/profile-identity.tsx
+++ b/src/features/settings/ui/profile-identity.tsx
@@ -1,0 +1,49 @@
+import type { SettingsProfile } from "@/entities/settings/model/types";
+
+interface ProfileIdentityProps {
+  profile: SettingsProfile;
+}
+
+export function ProfileIdentity({ profile }: ProfileIdentityProps) {
+  const initials = resolveInitials(profile);
+
+  return (
+    <div className="flex items-center gap-4">
+      <Avatar media={profile.avatarUrl} fallback={initials} />
+      <div className="space-y-1">
+        <p className="text-foreground text-lg font-semibold">
+          {profile.displayName ?? profile.username}
+        </p>
+        <p className="text-muted-foreground text-sm">@{profile.username}</p>
+      </div>
+    </div>
+  );
+}
+
+function resolveInitials(profile: SettingsProfile): string {
+  const label = profile.displayName ?? profile.username ?? "?";
+  return label
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function Avatar({ media, fallback }: { media?: string; fallback: string }) {
+  return (
+    <div className="bg-muted text-muted-foreground flex size-16 items-center justify-center overflow-hidden rounded-full border">
+      {media ? (
+        <img
+          src={media}
+          alt="사용자 아바타"
+          className="size-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <span className="text-base font-semibold">{fallback}</span>
+      )}
+    </div>
+  );
+}

--- a/src/mocks/handlers/handlers.ts
+++ b/src/mocks/handlers/handlers.ts
@@ -1,11 +1,13 @@
 import { authHandlers } from "./auth-handlers";
 import { dashboardHandlers } from "./dashboard-handlers";
-import { inventoryHandlers } from "./inventory-handlers";
 import { dungeonLogHandlers } from "./dungeon-log-handlers";
+import { inventoryHandlers } from "./inventory-handlers";
+import { settingsHandlers } from "./settings-handlers";
 
 export const handlers = [
   ...authHandlers,
   ...dashboardHandlers,
   ...dungeonLogHandlers,
   ...inventoryHandlers,
+  ...settingsHandlers,
 ];

--- a/src/mocks/handlers/settings-handlers.ts
+++ b/src/mocks/handlers/settings-handlers.ts
@@ -1,0 +1,132 @@
+import { http, HttpResponse } from "msw";
+import { EMBEDDING_ENDPOINTS, SETTINGS_ENDPOINTS } from "@/shared/config/env";
+import { mockDashboardResponse } from "@/mocks/handlers/dashboard-handlers";
+import { mockTimestampMinutesAgo } from "@/mocks/handlers/shared/time";
+import type { EmbeddingSize } from "@/entities/settings/model/types";
+
+const DEFAULT_USER_ID = "user-123";
+
+const mockSettingsResponse = {
+  profile: {
+    userId: DEFAULT_USER_ID,
+    username: "mock-user",
+    displayName: "Mocked Adventurer",
+    email: "mocked.adventurer@example.com",
+    avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+    joinedAt: "2023-11-02T12:00:00.000Z",
+    lastLoginAt: mockTimestampMinutesAgo(25),
+  },
+  connections: {
+    github: {
+      connected: true,
+      lastSyncAt: mockTimestampMinutesAgo(45),
+      profileUrl: "https://github.com/mock-user",
+    },
+  },
+};
+
+const EMBEDDING_SIZE_FALLBACK: EmbeddingSize = "compact";
+const EMBEDDING_SIZES: EmbeddingSize[] = ["compact", "square", "wide"];
+
+function resolveEmbeddingSize(rawSize?: string | null): EmbeddingSize {
+  if (!rawSize) {
+    return EMBEDDING_SIZE_FALLBACK;
+  }
+
+  if (EMBEDDING_SIZES.includes(rawSize as EmbeddingSize)) {
+    return rawSize as EmbeddingSize;
+  }
+
+  return EMBEDDING_SIZE_FALLBACK;
+}
+
+function createMockEquipmentPreview() {
+  const { state } = mockDashboardResponse;
+
+  const equipment = [
+    state.equippedWeapon,
+    state.equippedHelmet,
+    state.equippedArmor,
+    state.equippedRing,
+  ].filter(Boolean);
+
+  return equipment.map((item) => {
+    const safeItem = item!;
+    return {
+      id: safeItem.id,
+      name: safeItem.name,
+      slot: safeItem.slot,
+      rarity: safeItem.rarity,
+      modifiers: safeItem.modifiers,
+      effect: safeItem.effect ?? null,
+      sprite: buildSpriteFromName(safeItem.name),
+    };
+  });
+}
+
+function buildSpriteFromName(name: string): string {
+  const initials = name
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' rx='10' fill='#1f2937'/><text x='50%' y='52%' font-size='26' text-anchor='middle' fill='white' font-family='Inter, Arial, sans-serif' font-weight='700'>${initials}</text></svg>`;
+
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+function createMockEmbeddingPreview(size: EmbeddingSize) {
+  const { state } = mockDashboardResponse;
+  const equipment = createMockEquipmentPreview();
+
+  return {
+    userId: DEFAULT_USER_ID,
+    size,
+    level: state.level,
+    exp: state.exp,
+    expToLevel: state.expToLevel,
+    gold: state.gold,
+    bestFloor: state.maxFloor,
+    currentFloor: state.floor,
+    floorProgress: state.floorProgress,
+    stats: {
+      hp: {
+        current: state.hp,
+        max: state.maxHp,
+        equipmentBonus: undefined,
+      },
+      atk: {
+        total: state.atk,
+      },
+      def: {
+        total: state.def,
+      },
+      luck: {
+        total: state.luck,
+      },
+      ap: {
+        total: state.ap,
+      },
+    },
+    equipment,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+export const settingsHandlers = [
+  http.get(SETTINGS_ENDPOINTS.profile, () => {
+    return HttpResponse.json({ settings: mockSettingsResponse });
+  }),
+  http.get(EMBEDDING_ENDPOINTS.preview, ({ request }) => {
+    const url = new URL(request.url);
+    const sizeParam = url.searchParams.get("size");
+    const size = resolveEmbeddingSize(sizeParam);
+
+    return HttpResponse.json({
+      preview: createMockEmbeddingPreview(size),
+    });
+  }),
+];

--- a/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/src/pages/dashboard/ui/dashboard-page.tsx
@@ -35,6 +35,7 @@ export function DashboardPage() {
         exp={character.exp}
         expToLevel={character.expToLevel}
         gold={character.gold}
+        ap={character.ap}
         floor={character.floor}
         stats={character.stats}
         equipment={character.equipment}

--- a/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/src/pages/dashboard/ui/dashboard-page.tsx
@@ -1,22 +1,23 @@
-import { DashboardSummary } from "@/widgets/dashboard-summary/ui/dashboard-summary";
 import { DashboardActivity } from "@/widgets/dashboard-activity/ui/dashboard-activity";
-import { DashboardEquipment } from "@/widgets/dashboard-equipment/ui/dashboard-equipment";
 import { DashboardLogs } from "@/widgets/dashboard-logs/ui/dashboard-logs";
-import { useDashboardState } from "@/entities/dashboard/model/use-dashboard-state";
 import { useDungeonLogs } from "@/entities/dungeon-log/model/use-dungeon-logs";
 import { DASHBOARD_RECENT_LOG_LIMIT } from "@/pages/dashboard/config/constants";
+import { DashboardEmbeddingBanner } from "@/widgets/dashboard-embedding/ui/dashboard-embedding-banner";
+import { useCharacterOverview } from "@/features/character-summary/model/use-character-overview";
 
 export function DashboardPage() {
-  const { data: dashboardData } = useDashboardState();
+  const overview = useCharacterOverview();
   const { data: logsData } = useDungeonLogs({
     limit: DASHBOARD_RECENT_LOG_LIMIT,
   });
 
-  if (!dashboardData) {
+  const state = overview.dashboard.data?.state;
+  const character = overview.data;
+
+  if (!state || !character) {
     return null;
   }
 
-  const { state } = dashboardData;
   const logs = logsData?.logs ?? [];
   const latestLog = logs.at(0);
 
@@ -29,23 +30,25 @@ export function DashboardPage() {
         </p>
       </header>
 
-      <DashboardSummary state={state} />
+      <DashboardEmbeddingBanner
+        level={character.level}
+        exp={character.exp}
+        expToLevel={character.expToLevel}
+        gold={character.gold}
+        floor={character.floor}
+        stats={character.stats}
+        equipment={character.equipment}
+      />
 
-      <section className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+      <div>
         <DashboardActivity
           latestLog={latestLog}
-          apRemaining={state.ap}
+          apRemaining={character.stats.total.ap}
           currentAction={state.currentAction}
           lastActionCompletedAt={state.lastActionCompletedAt}
           nextActionStartAt={state.nextActionStartAt}
         />
-        <DashboardEquipment
-          helmet={state.equippedHelmet}
-          armor={state.equippedArmor}
-          weapon={state.equippedWeapon}
-          ring={state.equippedRing}
-        />
-      </section>
+      </div>
 
       <DashboardLogs logs={logs} />
     </section>

--- a/src/pages/inventory/ui/inventory-page.tsx
+++ b/src/pages/inventory/ui/inventory-page.tsx
@@ -1,15 +1,16 @@
-import { useInventory } from "@/entities/inventory/model/use-inventory";
 import { Card, CardContent } from "@/shared/ui/card";
 import { Button } from "@/shared/ui/button";
 import { InventoryLayout } from "@/widgets/inventory/ui/inventory-layout";
 import { useInventoryActions } from "@/features/inventory/model/use-inventory-actions";
+import { useCharacterOverview } from "@/features/character-summary/model/use-character-overview";
 
 export function InventoryPage() {
-  const { data, isLoading, isError, refetch, isFetching } = useInventory();
+  const overview = useCharacterOverview();
   const actions = useInventoryActions();
 
-  const showLoading = isLoading && !data;
-  const items = data?.items ?? [];
+  const inventoryData = overview.inventory.data;
+  const items = inventoryData?.items ?? [];
+  const showLoading = overview.isLoading && !inventoryData;
 
   return (
     <section className="space-y-6">
@@ -20,7 +21,7 @@ export function InventoryPage() {
         </p>
       </header>
 
-      {isError ? (
+      {overview.isError ? (
         <Card className="border-destructive/30">
           <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4 text-sm">
             <span className="text-destructive">
@@ -31,7 +32,7 @@ export function InventoryPage() {
               variant="outline"
               size="sm"
               onClick={() => {
-                void refetch();
+                void overview.refetch();
               }}
               className="text-xs"
             >
@@ -51,7 +52,10 @@ export function InventoryPage() {
         </Card>
       ) : null}
 
-      {!showLoading && !isFetching && !isError && items.length === 0 ? (
+      {!showLoading &&
+      !overview.isFetching &&
+      !overview.isError &&
+      items.length === 0 ? (
         <Card>
           <CardContent className="text-muted-foreground p-6 text-sm">
             아직 획득한 장비가 없습니다.
@@ -59,11 +63,11 @@ export function InventoryPage() {
         </Card>
       ) : null}
 
-      {data ? (
+      {inventoryData && overview.data ? (
         <InventoryLayout
-          items={data.items}
-          equipped={data.equipped}
-          summary={data.summary}
+          items={inventoryData.items}
+          equipped={inventoryData.equipped}
+          stats={overview.data.stats}
           isPending={actions.isPending}
           error={actions.error}
           onEquip={actions.equip}

--- a/src/pages/settings/ui/settings-page.tsx
+++ b/src/pages/settings/ui/settings-page.tsx
@@ -1,0 +1,140 @@
+import { Loader2, LogOut, RefreshCw } from "lucide-react";
+import type { JSX } from "react";
+import { useSettings } from "@/entities/settings/model/use-settings";
+import { SettingsProfileCard } from "@/widgets/settings-profile/ui/settings-profile-card";
+import { SettingsPreferencesCard } from "@/widgets/settings-preferences/ui/settings-preferences-card";
+import { SettingsEmbeddingPreviewCard } from "@/widgets/settings-embedding/ui/settings-embedding-preview-card";
+import { useLogout } from "@/features/auth/logout/model/use-logout";
+import { Button } from "@/shared/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/shared/ui/card";
+
+export function SettingsPage() {
+  const settingsQuery = useSettings();
+  const logoutMutation = useLogout();
+
+  const handleLogout = () => logoutMutation.mutateAsync();
+  const handleRetry = () => settingsQuery.refetch();
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-foreground text-2xl font-semibold">설정</h1>
+          <p className="text-muted-foreground text-sm">
+            계정 정보와 로컬 환경설정을 관리하고 임베딩 미리보기를 확인하세요.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="gap-2"
+          onClick={() => void handleLogout()}
+          disabled={logoutMutation.isPending}
+        >
+          {logoutMutation.isPending ? (
+            <Loader2 className="size-4 animate-spin" aria-hidden />
+          ) : (
+            <LogOut className="size-4" aria-hidden />
+          )}
+          로그아웃
+        </Button>
+      </header>
+
+      {settingsQuery.isError ? renderErrorBanner(handleRetry) : null}
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        {renderProfileSection(settingsQuery)}
+        <SettingsPreferencesCard />
+      </div>
+
+      <SettingsEmbeddingPreviewCard />
+    </section>
+  );
+}
+
+function renderProfileSection(
+  query: ReturnType<typeof useSettings>
+): JSX.Element {
+  if (query.isLoading) {
+    return (
+      <Card className="animate-pulse">
+        <CardHeader>
+          <CardTitle className="bg-muted h-5 w-36 rounded" />
+          <CardDescription className="bg-muted/80 h-4 w-64 rounded" />
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex items-center gap-4">
+            <div className="bg-muted size-16 rounded-full" />
+            <div className="space-y-2">
+              <div className="bg-muted h-4 w-32 rounded" />
+              <div className="bg-muted/80 h-3 w-24 rounded" />
+            </div>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="bg-muted/70 h-12 rounded" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!query.data) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>계정 정보</CardTitle>
+          <CardDescription>세션 정보를 불러올 수 없습니다.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            type="button"
+            variant="secondary"
+            className="gap-2"
+            onClick={() => void query.refetch()}
+          >
+            <RefreshCw className="size-4" aria-hidden />
+            다시 시도
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <SettingsProfileCard
+      profile={query.data.profile}
+      connections={query.data.connections}
+    />
+  );
+}
+
+function renderErrorBanner(onRetry: () => Promise<unknown>): JSX.Element {
+  return (
+    <div className="border-destructive/40 bg-destructive/10 text-destructive flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3">
+      <div>
+        <p className="font-semibold">설정 정보를 불러오지 못했습니다.</p>
+        <p className="text-destructive/80 text-sm">
+          네트워크 상태를 확인한 뒤 다시 시도하세요.
+        </p>
+      </div>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        className="gap-2"
+        onClick={() => void onRetry()}
+      >
+        <RefreshCw className="size-4" aria-hidden />
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Card, CardContent } from "@/shared/ui/card";
+import { SettingsPage } from "@/pages/settings/ui/settings-page";
 
 export const Route = createFileRoute("/settings")({
   beforeLoad: ({ context, location }) => context.auth.authorize({ location }),
@@ -8,19 +8,5 @@ export const Route = createFileRoute("/settings")({
 });
 
 function SettingsRoute() {
-  return (
-    <section className="space-y-4">
-      <header>
-        <h1 className="text-foreground text-2xl font-semibold">설정</h1>
-        <p className="text-muted-foreground text-sm">
-          테마, 언어, 임베딩 배너 미리보기를 이곳에서 관리합니다.
-        </p>
-      </header>
-      <Card className="border-dashed">
-        <CardContent className="text-muted-foreground p-6 text-sm">
-          환경설정 폼과 미리보기 위젯이 추가될 예정입니다.
-        </CardContent>
-      </Card>
-    </section>
-  );
+  return <SettingsPage />;
 }

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -23,6 +23,14 @@ export const INVENTORY_ENDPOINTS = {
   discard: "/api/inventory/discard",
 } as const;
 
+export const SETTINGS_ENDPOINTS = {
+  profile: "/api/settings",
+} as const;
+
+export const EMBEDDING_ENDPOINTS = {
+  preview: "/api/embedding/preview",
+} as const;
+
 export const IS_MSW_ENABLED =
   import.meta.env.DEV && import.meta.env.VITE_ENABLE_MSW === "true";
 

--- a/src/shared/lib/preferences/preferences.ts
+++ b/src/shared/lib/preferences/preferences.ts
@@ -1,0 +1,253 @@
+import {
+  DEFAULT_LANGUAGE_PREFERENCE,
+  DEFAULT_THEME_PREFERENCE,
+  LANGUAGE_PREFERENCE_VALUES,
+  THEME_PREFERENCE_VALUES,
+  type LanguagePreference,
+  type ThemePreference,
+} from "@/shared/lib/preferences/types";
+
+const STORAGE_KEYS = {
+  theme: "git-dungeon:theme",
+  language: "git-dungeon:language",
+} as const;
+
+type ThemeSubscriber = () => void;
+type LanguageSubscriber = () => void;
+
+const themeSubscribers = new Set<ThemeSubscriber>();
+const languageSubscribers = new Set<LanguageSubscriber>();
+
+let themePreference: ThemePreference = DEFAULT_THEME_PREFERENCE;
+let languagePreference: LanguagePreference = DEFAULT_LANGUAGE_PREFERENCE;
+
+const isBrowserEnvironment = typeof window !== "undefined";
+
+function safeReadStorage(key: string): string | null {
+  if (!isBrowserEnvironment) {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeWriteStorage(key: string, value: string) {
+  if (!isBrowserEnvironment) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // ignore write failures (private mode, quota, etc.)
+  }
+}
+
+function parseThemePreference(raw: string | null): ThemePreference | null {
+  if (!raw) {
+    return null;
+  }
+
+  return THEME_PREFERENCE_VALUES.includes(raw as ThemePreference)
+    ? (raw as ThemePreference)
+    : null;
+}
+
+function parseLanguagePreference(
+  raw: string | null
+): LanguagePreference | null {
+  if (!raw) {
+    return null;
+  }
+
+  return LANGUAGE_PREFERENCE_VALUES.includes(raw as LanguagePreference)
+    ? (raw as LanguagePreference)
+    : null;
+}
+
+function notifyThemeSubscribers() {
+  themeSubscribers.forEach((listener) => {
+    listener();
+  });
+}
+
+function notifyLanguageSubscribers() {
+  languageSubscribers.forEach((listener) => {
+    listener();
+  });
+}
+
+function resolveTheme(preference: ThemePreference): "light" | "dark" {
+  if (!isBrowserEnvironment) {
+    return preference === "dark" ? "dark" : "light";
+  }
+
+  if (preference === "system") {
+    try {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    } catch {
+      return "light";
+    }
+  }
+
+  return preference;
+}
+
+function applyThemeToDocument(preference: ThemePreference) {
+  if (!isBrowserEnvironment) {
+    return;
+  }
+
+  const mode = resolveTheme(preference);
+  const root = document.documentElement;
+
+  if (mode === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
+function applyLanguageToDocument(preference: LanguagePreference) {
+  if (!isBrowserEnvironment) {
+    return;
+  }
+
+  document.documentElement.lang = preference;
+}
+
+function initializePreferences() {
+  const storedTheme = parseThemePreference(safeReadStorage(STORAGE_KEYS.theme));
+  const storedLanguage = parseLanguagePreference(
+    safeReadStorage(STORAGE_KEYS.language)
+  );
+
+  if (storedTheme) {
+    themePreference = storedTheme;
+  }
+
+  if (storedLanguage) {
+    languagePreference = storedLanguage;
+  }
+
+  applyThemeToDocument(themePreference);
+  applyLanguageToDocument(languagePreference);
+}
+
+function handleStorageEvent(event: StorageEvent) {
+  if (!event.key) {
+    return;
+  }
+
+  if (event.key === STORAGE_KEYS.theme) {
+    const parsed =
+      parseThemePreference(event.newValue) ?? DEFAULT_THEME_PREFERENCE;
+    if (parsed !== themePreference) {
+      themePreference = parsed;
+      applyThemeToDocument(themePreference);
+      notifyThemeSubscribers();
+    }
+  }
+
+  if (event.key === STORAGE_KEYS.language) {
+    const parsed =
+      parseLanguagePreference(event.newValue) ?? DEFAULT_LANGUAGE_PREFERENCE;
+    if (parsed !== languagePreference) {
+      languagePreference = parsed;
+      applyLanguageToDocument(languagePreference);
+      notifyLanguageSubscribers();
+    }
+  }
+}
+
+function handleSystemThemeChange() {
+  if (themePreference === "system") {
+    applyThemeToDocument(themePreference);
+    notifyThemeSubscribers();
+  }
+}
+
+function bindBrowserListeners() {
+  if (!isBrowserEnvironment) {
+    return;
+  }
+
+  window.addEventListener("storage", handleStorageEvent);
+
+  try {
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", handleSystemThemeChange);
+    } else if (typeof media.addListener === "function") {
+      media.addListener(handleSystemThemeChange);
+    }
+  } catch {
+    // matchMedia may be unsupported; ignore silently
+  }
+}
+
+if (isBrowserEnvironment) {
+  initializePreferences();
+  bindBrowserListeners();
+}
+
+export function getThemePreference(): ThemePreference {
+  return themePreference;
+}
+
+export function setThemePreference(next: ThemePreference) {
+  if (next === themePreference) {
+    applyThemeToDocument(next);
+    return;
+  }
+
+  themePreference = next;
+  safeWriteStorage(STORAGE_KEYS.theme, next);
+  applyThemeToDocument(themePreference);
+  notifyThemeSubscribers();
+}
+
+export function subscribeThemePreference(
+  listener: ThemeSubscriber
+): () => void {
+  themeSubscribers.add(listener);
+  return () => {
+    themeSubscribers.delete(listener);
+  };
+}
+
+export function resolveThemePreference(
+  preference: ThemePreference
+): "light" | "dark" {
+  return resolveTheme(preference);
+}
+
+export function getLanguagePreference(): LanguagePreference {
+  return languagePreference;
+}
+
+export function setLanguagePreference(next: LanguagePreference) {
+  if (next === languagePreference) {
+    return;
+  }
+
+  languagePreference = next;
+  safeWriteStorage(STORAGE_KEYS.language, next);
+  applyLanguageToDocument(languagePreference);
+  notifyLanguageSubscribers();
+}
+
+export function subscribeLanguagePreference(
+  listener: LanguageSubscriber
+): () => void {
+  languageSubscribers.add(listener);
+  return () => {
+    languageSubscribers.delete(listener);
+  };
+}

--- a/src/shared/lib/preferences/types.ts
+++ b/src/shared/lib/preferences/types.ts
@@ -1,0 +1,11 @@
+export const THEME_PREFERENCE_VALUES = ["system", "light", "dark"] as const;
+
+export type ThemePreference = (typeof THEME_PREFERENCE_VALUES)[number];
+
+export const LANGUAGE_PREFERENCE_VALUES = ["ko", "en"] as const;
+
+export type LanguagePreference = (typeof LANGUAGE_PREFERENCE_VALUES)[number];
+
+export const DEFAULT_THEME_PREFERENCE: ThemePreference = "system";
+
+export const DEFAULT_LANGUAGE_PREFERENCE: LanguagePreference = "ko";

--- a/src/shared/ui/progress.tsx
+++ b/src/shared/ui/progress.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+
+import { cn } from "@/shared/lib/utils";
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="bg-primary h-full w-full flex-1 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/src/shared/ui/select.tsx
+++ b/src/shared/ui/select.tsx
@@ -1,0 +1,183 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/shared/ui/summary-tile.tsx
+++ b/src/shared/ui/summary-tile.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/shared/lib/utils";
+
+interface SummaryTileProps {
+  title: string;
+  value: string;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function SummaryTile({
+  title,
+  value,
+  children,
+  className,
+}: SummaryTileProps) {
+  return (
+    <div
+      className={cn(
+        "border-border bg-card flex flex-col gap-1 rounded-lg border p-4 shadow-sm",
+        className
+      )}
+    >
+      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {title}
+      </p>
+      <p className="text-foreground text-xl font-semibold">{value}</p>
+      {children}
+    </div>
+  );
+}

--- a/src/widgets/dashboard-embedding/lib/create-equipment-sprite.ts
+++ b/src/widgets/dashboard-embedding/lib/create-equipment-sprite.ts
@@ -1,0 +1,29 @@
+const BASE_COLORS = ["#1f2937", "#0f172a", "#4b5563", "#111827"];
+
+export function createEquipmentSprite(name: string): string {
+  const initials = name
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  const color = pickColor(name);
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' rx='10' fill='${color}'/><text x='50%' y='52%' font-size='26' text-anchor='middle' fill='white' font-family='Inter, Arial, sans-serif' font-weight='700'>${initials}</text></svg>`;
+
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+function pickColor(seed: string): string {
+  if (!seed) {
+    return BASE_COLORS[0];
+  }
+
+  const hash = Array.from(seed).reduce(
+    (acc, char) => acc + char.charCodeAt(0),
+    0
+  );
+  const index = hash % BASE_COLORS.length;
+  return BASE_COLORS[index];
+}

--- a/src/widgets/dashboard-embedding/ui/dashboard-embedding-banner.tsx
+++ b/src/widgets/dashboard-embedding/ui/dashboard-embedding-banner.tsx
@@ -1,21 +1,16 @@
-import { useMemo, type ReactNode } from "react";
-import type { InventoryItem } from "@/entities/inventory/model/types";
-import { InventoryItemCard } from "@/entities/inventory/ui/inventory-item-card";
-import { StatItem } from "@/entities/inventory/ui/stat-item";
-import { formatNumber } from "@/entities/dashboard/lib/formatters";
 import { cn } from "@/shared/lib/utils";
+import type { InventoryItem } from "@/entities/inventory/model/types";
 import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
-import { EmptySlot } from "@/widgets/inventory/ui/inventory-slots";
-import {
-  EQUIPMENT_SLOTS,
-  type EquipmentSlot,
-} from "@/entities/dashboard/model/types";
+import { CharacterOverviewHeader } from "@/features/character-summary/ui/character-overview-header";
+import { CharacterStatGrid } from "@/features/character-summary/ui/character-stat-grid";
+import { EquipmentSlotGrid } from "@/entities/inventory/ui/equipment-slot-grid";
 
 interface DashboardEmbeddingBannerProps {
   level: number;
   exp: number;
   expToLevel: number;
   gold: number;
+  ap: number;
   floor: {
     current: number;
     best: number;
@@ -31,24 +26,12 @@ export function DashboardEmbeddingBanner({
   exp,
   expToLevel,
   gold,
+  ap,
   floor,
   stats,
   equipment,
   layoutClassName,
 }: DashboardEmbeddingBannerProps) {
-  const expPercent = useMemo(() => {
-    if (expToLevel <= 0) {
-      return 0;
-    }
-    return Math.min(100, Math.round((exp / expToLevel) * 100));
-  }, [exp, expToLevel]);
-
-  const floorPercent = useMemo(() => {
-    return Math.min(100, Math.max(0, Math.round(floor.progress)));
-  }, [floor.progress]);
-
-  const equipmentMap = useMemo(() => buildEquipmentMap(equipment), [equipment]);
-
   return (
     <section
       className={cn(
@@ -57,152 +40,22 @@ export function DashboardEmbeddingBanner({
       )}
       aria-label="캐릭터 임베딩 정보"
     >
-      <header className="grid gap-4 lg:grid-cols-4">
-        <SummaryTile title="레벨" value={`Lv. ${level}`}>
-          <p className="text-muted-foreground text-xs">
-            {formatNumber(exp)} / {formatNumber(expToLevel)}
-          </p>
-          <ProgressBar value={expPercent} />
-        </SummaryTile>
-        <SummaryTile
-          title="층 진행"
-          value={`${floor.current}F / ${floor.best}F`}
-        >
-          <p className="text-muted-foreground text-xs">
-            진행도 {floorPercent}%
-          </p>
-          <ProgressBar value={floorPercent} />
-        </SummaryTile>
-        <SummaryTile title="골드" value={`${formatNumber(gold)} G`}>
-          <p className="text-muted-foreground text-xs">총 보유 골드</p>
-        </SummaryTile>
-        <SummaryTile title="AP" value={`${formatNumber(stats.total.ap)}`}>
-          <p className="text-muted-foreground text-xs">행동력</p>
-        </SummaryTile>
-      </header>
+      <CharacterOverviewHeader
+        level={level}
+        exp={exp}
+        expToLevel={expToLevel}
+        floor={floor}
+        gold={gold}
+        ap={ap}
+      />
 
       <section className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-          {renderStatItems(stats)}
-        </div>
-        <aside className="space-y-3">
+        <CharacterStatGrid stats={stats} />
+        <div className="space-y-3">
           <h3 className="text-foreground text-sm font-semibold">착용 장비</h3>
-          <div className="grid grid-cols-2 gap-3">
-            {EQUIPMENT_SLOTS.map((slot) => {
-              const item = equipmentMap[slot];
-              return (
-                <div
-                  key={slot}
-                  className="border-border bg-background flex h-auto w-full flex-col items-center justify-center gap-2 rounded-lg border p-3 text-center"
-                >
-                  {item ? (
-                    <InventoryItemCard
-                      item={item}
-                      className="items-center"
-                      showSlotLabel
-                    />
-                  ) : (
-                    <EmptySlot slot={slot} />
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </aside>
+          <EquipmentSlotGrid equipped={equipment} />
+        </div>
       </section>
     </section>
-  );
-}
-
-interface SummaryTileProps {
-  title: string;
-  value: string;
-  children?: ReactNode;
-}
-
-function SummaryTile({ title, value, children }: SummaryTileProps) {
-  return (
-    <div className="border-border bg-card flex flex-col gap-1 rounded-lg border p-4 shadow-sm">
-      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-        {title}
-      </p>
-      <p className="text-foreground text-xl font-semibold">{value}</p>
-      {children}
-    </div>
-  );
-}
-
-interface ProgressBarProps {
-  value: number;
-}
-
-function ProgressBar({ value }: ProgressBarProps) {
-  return (
-    <div className="bg-muted relative h-2 w-full overflow-hidden rounded-full">
-      <div
-        className="bg-primary absolute top-0 left-0 h-full"
-        style={{ width: `${value}%` }}
-        aria-hidden
-      />
-      <span className="sr-only">{value}%</span>
-    </div>
-  );
-}
-
-function renderStatItems(stats: CharacterStatSummary) {
-  const entries = [
-    {
-      key: "hp",
-      title: "HP",
-      caption: `최대 HP ${formatNumber(stats.total.maxHp)}`,
-      total: stats.total.hp,
-      bonus: stats.equipmentBonus.hp,
-    },
-    {
-      key: "atk",
-      title: "ATK",
-      caption: "공격력",
-      total: stats.total.atk,
-      bonus: stats.equipmentBonus.atk,
-    },
-    {
-      key: "def",
-      title: "DEF",
-      caption: "방어력",
-      total: stats.total.def,
-      bonus: stats.equipmentBonus.def,
-    },
-    {
-      key: "luck",
-      title: "LUCK",
-      caption: "행운",
-      total: stats.total.luck,
-      bonus: stats.equipmentBonus.luck,
-    },
-  ];
-
-  return entries.map((entry) => (
-    <StatItem
-      key={entry.key}
-      title={entry.title}
-      caption={entry.caption}
-      total={entry.total}
-      equipmentBonus={entry.bonus}
-    />
-  ));
-}
-
-function buildEquipmentMap(items: InventoryItem[]) {
-  return EQUIPMENT_SLOTS.reduce<Record<EquipmentSlot, InventoryItem | null>>(
-    (acc, slot) => {
-      acc[slot] = items.find((item) => item.slot === slot) ?? null;
-      return acc;
-    },
-    {
-      helmet: null,
-      armor: null,
-      weapon: null,
-      ring: null,
-    }
   );
 }

--- a/src/widgets/dashboard-embedding/ui/dashboard-embedding-banner.tsx
+++ b/src/widgets/dashboard-embedding/ui/dashboard-embedding-banner.tsx
@@ -1,0 +1,221 @@
+import { useMemo, type ReactNode } from "react";
+import type { InventoryItem } from "@/entities/inventory/model/types";
+import { InventoryItemCard } from "@/entities/inventory/ui/inventory-item-card";
+import { StatItem } from "@/entities/inventory/ui/stat-item";
+import { formatNumber } from "@/entities/dashboard/lib/formatters";
+import { cn } from "@/shared/lib/utils";
+import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
+import { EmptySlot } from "@/widgets/inventory/ui/inventory-slots";
+import {
+  EQUIPMENT_SLOTS,
+  type EquipmentSlot,
+} from "@/entities/dashboard/model/types";
+
+interface DashboardEmbeddingBannerProps {
+  level: number;
+  exp: number;
+  expToLevel: number;
+  gold: number;
+  floor: {
+    current: number;
+    best: number;
+    progress: number;
+  };
+  stats: CharacterStatSummary;
+  equipment: InventoryItem[];
+  layoutClassName?: string;
+}
+
+const SUMMARY_TILE_CLASSNAME =
+  "border-border bg-card flex flex-col gap-1 rounded-lg border p-4 shadow-sm";
+
+export function DashboardEmbeddingBanner({
+  level,
+  exp,
+  expToLevel,
+  gold,
+  floor,
+  stats,
+  equipment,
+  layoutClassName,
+}: DashboardEmbeddingBannerProps) {
+  const expPercent = useMemo(() => {
+    if (expToLevel <= 0) {
+      return 0;
+    }
+    return Math.min(100, Math.round((exp / expToLevel) * 100));
+  }, [exp, expToLevel]);
+
+  const floorPercent = useMemo(() => {
+    return Math.min(100, Math.max(0, Math.round(floor.progress)));
+  }, [floor.progress]);
+
+  const equipmentMap = useMemo(() => buildEquipmentMap(equipment), [equipment]);
+
+  return (
+    <section
+      className={cn(
+        "from-background to-muted/40 border-border space-y-6 rounded-2xl border bg-gradient-to-br p-6 shadow-sm",
+        layoutClassName
+      )}
+      aria-label="캐릭터 임베딩 정보"
+    >
+      <header className="grid gap-4 lg:grid-cols-4">
+        <SummaryTile title="레벨" value={`Lv. ${level}`}>
+          <p className="text-muted-foreground text-xs">
+            다음 레벨까지 {formatNumber(Math.max(expToLevel - exp, 0))} EXP
+          </p>
+        </SummaryTile>
+        <SummaryTile
+          title="층 진행"
+          value={`${floor.current}F / ${floor.best}F`}
+        >
+          <p className="text-muted-foreground text-xs">
+            진행도 {floorPercent}%
+          </p>
+          <ProgressBar value={floorPercent} />
+        </SummaryTile>
+        <SummaryTile title="골드" value={`${formatNumber(gold)} G`}>
+          <p className="text-muted-foreground text-xs">총 보유 골드</p>
+        </SummaryTile>
+        <SummaryTile
+          title="경험치"
+          value={`${formatNumber(exp)} / ${formatNumber(expToLevel)}`}
+        >
+          <p className="text-muted-foreground text-xs">진행률 {expPercent}%</p>
+          <ProgressBar value={expPercent} />
+        </SummaryTile>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {renderStatItems(stats)}
+        </div>
+        <aside className="space-y-3">
+          <h3 className="text-foreground text-sm font-semibold">착용 장비</h3>
+          <div className="grid grid-cols-2 gap-3">
+            {EQUIPMENT_SLOTS.map((slot) => {
+              const item = equipmentMap[slot];
+              return (
+                <div
+                  key={slot}
+                  className="border-border bg-background flex h-auto w-full flex-col items-center justify-center gap-2 rounded-lg border p-3 text-center"
+                >
+                  {item ? (
+                    <InventoryItemCard
+                      item={item}
+                      className="items-center"
+                      showSlotLabel
+                    />
+                  ) : (
+                    <EmptySlot slot={slot} />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </aside>
+      </section>
+    </section>
+  );
+}
+
+interface SummaryTileProps {
+  title: string;
+  value: string;
+  children?: ReactNode;
+}
+
+function SummaryTile({ title, value, children }: SummaryTileProps) {
+  return (
+    <div className={SUMMARY_TILE_CLASSNAME}>
+      <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {title}
+      </p>
+      <p className="text-foreground text-xl font-semibold">{value}</p>
+      {children}
+    </div>
+  );
+}
+
+interface ProgressBarProps {
+  value: number;
+}
+
+function ProgressBar({ value }: ProgressBarProps) {
+  return (
+    <div className="bg-muted relative h-2 w-full overflow-hidden rounded-full">
+      <div
+        className="bg-primary absolute top-0 left-0 h-full"
+        style={{ width: `${value}%` }}
+        aria-hidden
+      />
+      <span className="sr-only">{value}%</span>
+    </div>
+  );
+}
+
+function renderStatItems(stats: CharacterStatSummary) {
+  const entries = [
+    {
+      key: "hp",
+      title: "HP",
+      caption: `최대 HP ${formatNumber(stats.total.maxHp)}`,
+      total: stats.total.hp,
+      bonus: stats.equipmentBonus.hp,
+    },
+    {
+      key: "atk",
+      title: "ATK",
+      caption: "공격력",
+      total: stats.total.atk,
+      bonus: stats.equipmentBonus.atk,
+    },
+    {
+      key: "def",
+      title: "DEF",
+      caption: "방어력",
+      total: stats.total.def,
+      bonus: stats.equipmentBonus.def,
+    },
+    {
+      key: "luck",
+      title: "LUCK",
+      caption: "행운",
+      total: stats.total.luck,
+      bonus: stats.equipmentBonus.luck,
+    },
+    {
+      key: "ap",
+      title: "AP",
+      caption: "행동력",
+      total: stats.total.ap,
+      bonus: stats.equipmentBonus.ap,
+    },
+  ];
+
+  return entries.map((entry) => (
+    <StatItem
+      key={entry.key}
+      title={entry.title}
+      caption={entry.caption}
+      total={entry.total}
+      equipmentBonus={entry.bonus}
+    />
+  ));
+}
+
+function buildEquipmentMap(items: InventoryItem[]) {
+  return EQUIPMENT_SLOTS.reduce<Record<EquipmentSlot, InventoryItem | null>>(
+    (acc, slot) => {
+      acc[slot] = items.find((item) => item.slot === slot) ?? null;
+      return acc;
+    },
+    {
+      helmet: null,
+      armor: null,
+      weapon: null,
+      ring: null,
+    }
+  );
+}

--- a/src/widgets/dashboard-embedding/ui/dashboard-embedding-banner.tsx
+++ b/src/widgets/dashboard-embedding/ui/dashboard-embedding-banner.tsx
@@ -50,7 +50,10 @@ export function DashboardEmbeddingBanner({
       />
 
       <section className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
-        <CharacterStatGrid stats={stats} />
+        <div className="space-y-3">
+          <h3 className="text-foreground text-sm font-semibold">능력치</h3>
+          <CharacterStatGrid stats={stats} />
+        </div>
         <div className="space-y-3">
           <h3 className="text-foreground text-sm font-semibold">착용 장비</h3>
           <EquipmentSlotGrid equipped={equipment} />

--- a/src/widgets/dashboard-embedding/ui/dashboard-embedding-banner.tsx
+++ b/src/widgets/dashboard-embedding/ui/dashboard-embedding-banner.tsx
@@ -26,9 +26,6 @@ interface DashboardEmbeddingBannerProps {
   layoutClassName?: string;
 }
 
-const SUMMARY_TILE_CLASSNAME =
-  "border-border bg-card flex flex-col gap-1 rounded-lg border p-4 shadow-sm";
-
 export function DashboardEmbeddingBanner({
   level,
   exp,
@@ -63,8 +60,9 @@ export function DashboardEmbeddingBanner({
       <header className="grid gap-4 lg:grid-cols-4">
         <SummaryTile title="레벨" value={`Lv. ${level}`}>
           <p className="text-muted-foreground text-xs">
-            다음 레벨까지 {formatNumber(Math.max(expToLevel - exp, 0))} EXP
+            {formatNumber(exp)} / {formatNumber(expToLevel)}
           </p>
+          <ProgressBar value={expPercent} />
         </SummaryTile>
         <SummaryTile
           title="층 진행"
@@ -78,12 +76,8 @@ export function DashboardEmbeddingBanner({
         <SummaryTile title="골드" value={`${formatNumber(gold)} G`}>
           <p className="text-muted-foreground text-xs">총 보유 골드</p>
         </SummaryTile>
-        <SummaryTile
-          title="경험치"
-          value={`${formatNumber(exp)} / ${formatNumber(expToLevel)}`}
-        >
-          <p className="text-muted-foreground text-xs">진행률 {expPercent}%</p>
-          <ProgressBar value={expPercent} />
+        <SummaryTile title="AP" value={`${formatNumber(stats.total.ap)}`}>
+          <p className="text-muted-foreground text-xs">행동력</p>
         </SummaryTile>
       </header>
 
@@ -128,7 +122,7 @@ interface SummaryTileProps {
 
 function SummaryTile({ title, value, children }: SummaryTileProps) {
   return (
-    <div className={SUMMARY_TILE_CLASSNAME}>
+    <div className="border-border bg-card flex flex-col gap-1 rounded-lg border p-4 shadow-sm">
       <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
         {title}
       </p>
@@ -184,13 +178,6 @@ function renderStatItems(stats: CharacterStatSummary) {
       caption: "행운",
       total: stats.total.luck,
       bonus: stats.equipmentBonus.luck,
-    },
-    {
-      key: "ap",
-      title: "AP",
-      caption: "행동력",
-      total: stats.total.ap,
-      bonus: stats.equipmentBonus.ap,
     },
   ];
 

--- a/src/widgets/dungeon-log-timeline/ui/dungeon-log-detail-dialog.tsx
+++ b/src/widgets/dungeon-log-timeline/ui/dungeon-log-detail-dialog.tsx
@@ -10,11 +10,13 @@ import {
 import { DeltaList } from "@/entities/dungeon-log/ui/delta-list";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/shared/ui/dialog";
+import { Button } from "@/shared/ui/button";
 
 interface DungeonLogDetailDialogProps {
   log: DungeonLogEntry | null;
@@ -41,6 +43,16 @@ export function DungeonLogDetailDialog({
               <DialogDescription className="text-left">
                 {buildLogDescription(log)}
               </DialogDescription>
+              <DialogClose asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="닫기"
+                  className="absolute top-4 right-4"
+                >
+                  ✕
+                </Button>
+              </DialogClose>
             </DialogHeader>
 
             <div className="space-y-2">

--- a/src/widgets/inventory/ui/inventory-character-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-character-panel.tsx
@@ -54,12 +54,6 @@ export function InventoryCharacterPanel({
             total={total.luck}
             equipmentBonus={equipmentBonus.luck}
           />
-          <StatItem
-            title="AP"
-            caption="행동력"
-            total={total.ap}
-            equipmentBonus={equipmentBonus.ap}
-          />
         </div>
       </CardContent>
     </Card>

--- a/src/widgets/inventory/ui/inventory-character-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-character-panel.tsx
@@ -1,7 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
-import { StatItem } from "@/entities/inventory/ui/stat-item";
 import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
-import { formatNumber } from "@/entities/dashboard/lib/formatters";
+import { CharacterStatGrid } from "@/features/character-summary/ui/character-stat-grid";
 
 interface InventoryCharacterPanelProps {
   stats: CharacterStatSummary;
@@ -10,8 +9,6 @@ interface InventoryCharacterPanelProps {
 export function InventoryCharacterPanel({
   stats,
 }: InventoryCharacterPanelProps) {
-  const { total, equipmentBonus } = stats;
-
   return (
     <Card>
       <CardHeader>
@@ -29,32 +26,7 @@ export function InventoryCharacterPanel({
           <p className="mt-4 text-sm">현재 능력치</p>
         </div>
 
-        <div className="grid gap-3 text-sm sm:grid-cols-2">
-          <StatItem
-            title="HP"
-            caption={`최대 HP ${formatNumber(total.maxHp)}`}
-            total={total.hp}
-            equipmentBonus={equipmentBonus.hp}
-          />
-          <StatItem
-            title="ATK"
-            caption="공격력"
-            total={total.atk}
-            equipmentBonus={equipmentBonus.atk}
-          />
-          <StatItem
-            title="DEF"
-            caption="방어력"
-            total={total.def}
-            equipmentBonus={equipmentBonus.def}
-          />
-          <StatItem
-            title="LUCK"
-            caption="행운"
-            total={total.luck}
-            equipmentBonus={equipmentBonus.luck}
-          />
-        </div>
+        <CharacterStatGrid stats={stats} />
       </CardContent>
     </Card>
   );

--- a/src/widgets/inventory/ui/inventory-character-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-character-panel.tsx
@@ -1,15 +1,16 @@
-import type { InventorySummary } from "@/entities/inventory/model/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { StatItem } from "@/entities/inventory/ui/stat-item";
+import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
+import { formatNumber } from "@/entities/dashboard/lib/formatters";
 
 interface InventoryCharacterPanelProps {
-  summary: InventorySummary;
+  stats: CharacterStatSummary;
 }
 
 export function InventoryCharacterPanel({
-  summary,
+  stats,
 }: InventoryCharacterPanelProps) {
-  const { total, equipmentBonus } = summary;
+  const { total, equipmentBonus } = stats;
 
   return (
     <Card>
@@ -28,10 +29,10 @@ export function InventoryCharacterPanel({
           <p className="mt-4 text-sm">현재 능력치</p>
         </div>
 
-        <div className="grid grid-cols-2 gap-3 text-sm">
+        <div className="grid gap-3 text-sm sm:grid-cols-2">
           <StatItem
             title="HP"
-            caption="체력"
+            caption={`최대 HP ${formatNumber(total.maxHp)}`}
             total={total.hp}
             equipmentBonus={equipmentBonus.hp}
           />
@@ -52,6 +53,12 @@ export function InventoryCharacterPanel({
             caption="행운"
             total={total.luck}
             equipmentBonus={equipmentBonus.luck}
+          />
+          <StatItem
+            title="AP"
+            caption="행동력"
+            total={total.ap}
+            equipmentBonus={equipmentBonus.ap}
           />
         </div>
       </CardContent>

--- a/src/widgets/inventory/ui/inventory-layout.tsx
+++ b/src/widgets/inventory/ui/inventory-layout.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from "react";
 import type {
   InventoryEquippedMap,
   InventoryItem,
-  InventorySummary,
 } from "@/entities/inventory/model/types";
 import type { EquipmentSlot } from "@/entities/dashboard/model/types";
 import { InventorySlots } from "@/widgets/inventory/ui/inventory-slots";
@@ -10,11 +9,12 @@ import { InventoryCharacterPanel } from "@/widgets/inventory/ui/inventory-charac
 import { InventoryGrid } from "@/widgets/inventory/ui/inventory-grid";
 import { InventoryModal } from "@/widgets/inventory/ui/inventory-modal";
 import { HintCard } from "@/entities/inventory/ui/hint-card";
+import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
 
 interface InventoryLayoutProps {
   items: InventoryItem[];
   equipped: InventoryEquippedMap;
-  summary: InventorySummary;
+  stats: CharacterStatSummary;
   isPending: boolean;
   error: Error | null;
   onEquip: (itemId: string) => Promise<unknown>;
@@ -25,7 +25,7 @@ interface InventoryLayoutProps {
 export function InventoryLayout({
   items,
   equipped,
-  summary,
+  stats,
   isPending,
   error,
   onEquip,
@@ -63,7 +63,7 @@ export function InventoryLayout({
         />
 
         <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
-          <InventoryCharacterPanel summary={summary} />
+          <InventoryCharacterPanel stats={stats} />
           <HintCard />
         </div>
       </div>

--- a/src/widgets/inventory/ui/inventory-slots.tsx
+++ b/src/widgets/inventory/ui/inventory-slots.tsx
@@ -55,7 +55,7 @@ export function InventorySlots({ equipped, onSelect }: InventorySlotsProps) {
   );
 }
 
-function EmptySlot({ slot }: { slot: EquipmentSlot }) {
+export function EmptySlot({ slot }: { slot: EquipmentSlot }) {
   return (
     <div className="flex w-full flex-col items-center gap-2 text-center">
       <div className="border-border flex size-14 items-center justify-center rounded-md border border-dashed" />

--- a/src/widgets/inventory/ui/inventory-slots.tsx
+++ b/src/widgets/inventory/ui/inventory-slots.tsx
@@ -3,10 +3,13 @@ import type {
   InventoryItem,
 } from "@/entities/inventory/model/types";
 import type { EquipmentSlot } from "@/entities/dashboard/model/types";
-import { InventoryItemCard } from "@/entities/inventory/ui/inventory-item-card";
-import { getInventorySlotLabel } from "@/entities/inventory/config/slot-labels";
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
 import { Button } from "@/shared/ui/button";
+import {
+  EquipmentSlotGrid,
+  InventoryEmptySlot,
+} from "@/entities/inventory/ui/equipment-slot-grid";
+import { InventoryItemCard } from "@/entities/inventory/ui/inventory-item-card";
 import { cn } from "@/shared/lib/utils";
 
 interface InventorySlotsProps {
@@ -22,12 +25,9 @@ export function InventorySlots({ equipped, onSelect }: InventorySlotsProps) {
         <CardTitle className="text-base">장착 슬롯</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-2 gap-3">
-          {(
-            Object.entries(equipped) as Array<
-              [EquipmentSlot, InventoryItem | null]
-            >
-          ).map(([slot, item]) => (
+        <EquipmentSlotGrid
+          equipped={equipped}
+          renderSlot={(slot, item) => (
             <Button
               key={slot}
               type="button"
@@ -45,26 +45,12 @@ export function InventorySlots({ equipped, onSelect }: InventorySlotsProps) {
               {item ? (
                 <InventoryItemCard item={item} />
               ) : (
-                <EmptySlot slot={slot} />
+                <InventoryEmptySlot slot={slot} />
               )}
             </Button>
-          ))}
-        </div>
+          )}
+        />
       </CardContent>
     </Card>
-  );
-}
-
-export function EmptySlot({ slot }: { slot: EquipmentSlot }) {
-  return (
-    <div className="flex w-full flex-col items-center gap-2 text-center">
-      <div className="border-border flex size-14 items-center justify-center rounded-md border border-dashed" />
-      <div className="space-y-1">
-        <p className="text-xs font-semibold tracking-wide">
-          {getInventorySlotLabel(slot)}
-        </p>
-        <p className="text-muted-foreground text-[11px]">장비 없음</p>
-      </div>
-    </div>
   );
 }

--- a/src/widgets/settings-embedding/ui/settings-embedding-preview-card.tsx
+++ b/src/widgets/settings-embedding/ui/settings-embedding-preview-card.tsx
@@ -95,6 +95,7 @@ function renderPreviewContent(
         exp={character.exp}
         expToLevel={character.expToLevel}
         gold={character.gold}
+        ap={character.ap}
         floor={character.floor}
         stats={character.stats}
         equipment={character.equipment}

--- a/src/widgets/settings-embedding/ui/settings-embedding-preview-card.tsx
+++ b/src/widgets/settings-embedding/ui/settings-embedding-preview-card.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from "react";
+import type { EmbeddingSize } from "@/entities/settings/model/types";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/shared/ui/card";
+import { Button, buttonVariants } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/utils";
+import { formatDateTime } from "@/shared/lib/datetime/formatters";
+import { DashboardEmbeddingBanner } from "@/widgets/dashboard-embedding/ui/dashboard-embedding-banner";
+import { useCharacterOverview } from "@/features/character-summary/model/use-character-overview";
+import type { CharacterOverview } from "@/features/character-summary/lib/build-character-overview";
+
+const EMBEDDING_SIZE_OPTIONS: Array<{
+  value: EmbeddingSize;
+  label: string;
+  hint: string;
+}> = [
+  { value: "compact", label: "Compact", hint: "블로그 사이드바" },
+  { value: "square", label: "Square", hint: "README 카드" },
+  { value: "wide", label: "Wide", hint: "대시보드 배너" },
+];
+
+export function SettingsEmbeddingPreviewCard() {
+  const [size, setSize] = useState<EmbeddingSize>("compact");
+  const overview = useCharacterOverview();
+
+  const isPending = overview.isLoading || overview.isFetching;
+  const character = overview.data;
+
+  const generatedAtLabel = useMemo(() => {
+    return formatDateTime(new Date());
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <CardTitle>캐릭터 대시보드</CardTitle>
+          <CardDescription>
+            대시보드와 인벤토리 데이터를 조합한 임베딩 미리보기입니다.
+          </CardDescription>
+        </div>
+        <CardAction className="flex items-center gap-2">
+          {EMBEDDING_SIZE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className={cn(
+                buttonVariants({
+                  variant: option.value === size ? "default" : "outline",
+                  size: "sm",
+                }),
+                "flex flex-col gap-0 text-xs"
+              )}
+              onClick={() => setSize(option.value)}
+              disabled={isPending}
+            >
+              <span>{option.label}</span>
+              <span className="text-muted-foreground text-[10px]">
+                {option.hint}
+              </span>
+            </button>
+          ))}
+        </CardAction>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {overview.isError
+          ? renderErrorState(overview.refetch)
+          : isPending
+            ? renderSkeletonPreview()
+            : character
+              ? renderPreviewContent(size, character, generatedAtLabel)
+              : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function renderPreviewContent(
+  size: EmbeddingSize,
+  character: CharacterOverview,
+  generatedAtLabel: string
+) {
+  const layoutClassName = resolveLayoutClassName(size);
+
+  return (
+    <div className="space-y-4">
+      <DashboardEmbeddingBanner
+        level={character.level}
+        exp={character.exp}
+        expToLevel={character.expToLevel}
+        gold={character.gold}
+        floor={character.floor}
+        stats={character.stats}
+        equipment={character.equipment}
+        layoutClassName={layoutClassName}
+      />
+      <div className="text-muted-foreground flex flex-col gap-2 text-xs sm:flex-row sm:items-center sm:justify-between">
+        <span>생성 시각: {generatedAtLabel}</span>
+        <span>
+          URL 예시:{" "}
+          <code className="font-mono text-xs">
+            /render?userId=me&amp;size={size}
+          </code>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function renderErrorState(onRetry: () => Promise<void>) {
+  return (
+    <div className="bg-destructive/5 text-destructive border-destructive/20 flex flex-col items-start gap-3 rounded-lg border p-6">
+      <div>
+        <p className="font-semibold">미리보기를 불러오지 못했습니다.</p>
+        <p className="text-destructive/80 text-sm">
+          네트워크 상태를 확인한 뒤 다시 시도하세요.
+        </p>
+      </div>
+      <Button variant="destructive" size="sm" onClick={() => void onRetry()}>
+        다시 시도
+      </Button>
+    </div>
+  );
+}
+
+function renderSkeletonPreview() {
+  return (
+    <div className="space-y-4">
+      <div className="bg-muted/20 h-64 animate-pulse rounded-2xl" />
+      <div className="bg-muted/20 h-4 w-1/3 animate-pulse rounded" />
+    </div>
+  );
+}
+
+function resolveLayoutClassName(size: EmbeddingSize): string | undefined {
+  if (size === "compact") {
+    return "p-4 text-sm";
+  }
+
+  if (size === "wide") {
+    return "p-8";
+  }
+
+  return undefined;
+}

--- a/src/widgets/settings-preferences/ui/settings-preferences-card.tsx
+++ b/src/widgets/settings-preferences/ui/settings-preferences-card.tsx
@@ -1,13 +1,3 @@
-import { useCallback, type ChangeEvent } from "react";
-import { useSettingsPreferences } from "@/features/settings/model/use-settings-preferences";
-import type {
-  LanguagePreference,
-  ThemePreference,
-} from "@/shared/lib/preferences/types";
-import {
-  LANGUAGE_PREFERENCE_VALUES,
-  THEME_PREFERENCE_VALUES,
-} from "@/shared/lib/preferences/types";
 import {
   Card,
   CardContent,
@@ -15,34 +5,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/shared/ui/card";
-
-const THEME_LABEL_MAP: Record<ThemePreference, string> = {
-  system: "시스템 기본값",
-  light: "라이트",
-  dark: "다크",
-};
-
-const LANGUAGE_LABEL_MAP: Record<LanguagePreference, string> = {
-  ko: "한국어",
-  en: "English",
-};
+import { useSettingsPreferences } from "@/features/settings/model/use-settings-preferences";
+import { PreferencesForm } from "@/features/settings/ui/preferences-form";
 
 export function SettingsPreferencesCard() {
   const { theme, setTheme, language, setLanguage } = useSettingsPreferences();
-
-  const handleThemeChange = useCallback(
-    (event: ChangeEvent<HTMLSelectElement>) => {
-      setTheme(event.target.value as ThemePreference);
-    },
-    [setTheme]
-  );
-
-  const handleLanguageChange = useCallback(
-    (event: ChangeEvent<HTMLSelectElement>) => {
-      setLanguage(event.target.value as LanguagePreference);
-    },
-    [setLanguage]
-  );
 
   return (
     <Card>
@@ -50,73 +17,14 @@ export function SettingsPreferencesCard() {
         <CardTitle>환경 설정</CardTitle>
         <CardDescription>테마와 언어를 관리합니다.</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-6">
-        <Fieldset
-          label="테마"
-          controlId="settings-theme"
-          control={
-            <div className="flex items-center gap-3">
-              <select
-                id="settings-theme"
-                name="theme"
-                className="bg-background text-foreground focus-visible:ring-ring focus-visible:ring-offset-background inline-flex h-10 flex-1 items-center rounded-md border px-3 text-sm shadow-sm"
-                value={theme}
-                onChange={handleThemeChange}
-              >
-                {THEME_PREFERENCE_VALUES.map((preference) => (
-                  <option key={preference} value={preference}>
-                    {THEME_LABEL_MAP[preference]}
-                  </option>
-                ))}
-              </select>
-            </div>
-          }
-        />
-
-        <Fieldset
-          label="언어"
-          controlId="settings-language"
-          control={
-            <div className="flex items-center gap-3">
-              <select
-                id="settings-language"
-                name="language"
-                className="bg-background text-foreground focus-visible:ring-ring focus-visible:ring-offset-background inline-flex h-10 flex-1 items-center rounded-md border px-3 text-sm shadow-sm"
-                value={language}
-                onChange={handleLanguageChange}
-              >
-                {LANGUAGE_PREFERENCE_VALUES.map((preference) => (
-                  <option key={preference} value={preference}>
-                    {LANGUAGE_LABEL_MAP[preference]}
-                  </option>
-                ))}
-              </select>
-            </div>
-          }
+      <CardContent>
+        <PreferencesForm
+          theme={theme}
+          language={language}
+          onThemeChange={setTheme}
+          onLanguageChange={setLanguage}
         />
       </CardContent>
     </Card>
-  );
-}
-
-interface FieldsetProps {
-  label: string;
-  controlId: string;
-  description?: string;
-  control: React.ReactNode;
-}
-
-function Fieldset({ label, description, controlId, control }: FieldsetProps) {
-  return (
-    <fieldset className="flex flex-col gap-2">
-      <label
-        htmlFor={controlId}
-        className="text-foreground text-sm font-medium"
-      >
-        {label}
-      </label>
-      {control}
-      <p className="text-muted-foreground text-xs">{description}</p>
-    </fieldset>
   );
 }

--- a/src/widgets/settings-preferences/ui/settings-preferences-card.tsx
+++ b/src/widgets/settings-preferences/ui/settings-preferences-card.tsx
@@ -1,0 +1,122 @@
+import { useCallback, type ChangeEvent } from "react";
+import { useSettingsPreferences } from "@/features/settings/model/use-settings-preferences";
+import type {
+  LanguagePreference,
+  ThemePreference,
+} from "@/shared/lib/preferences/types";
+import {
+  LANGUAGE_PREFERENCE_VALUES,
+  THEME_PREFERENCE_VALUES,
+} from "@/shared/lib/preferences/types";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/shared/ui/card";
+
+const THEME_LABEL_MAP: Record<ThemePreference, string> = {
+  system: "시스템 기본값",
+  light: "라이트",
+  dark: "다크",
+};
+
+const LANGUAGE_LABEL_MAP: Record<LanguagePreference, string> = {
+  ko: "한국어",
+  en: "English",
+};
+
+export function SettingsPreferencesCard() {
+  const { theme, setTheme, language, setLanguage } = useSettingsPreferences();
+
+  const handleThemeChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      setTheme(event.target.value as ThemePreference);
+    },
+    [setTheme]
+  );
+
+  const handleLanguageChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      setLanguage(event.target.value as LanguagePreference);
+    },
+    [setLanguage]
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>환경 설정</CardTitle>
+        <CardDescription>테마와 언어를 관리합니다.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Fieldset
+          label="테마"
+          controlId="settings-theme"
+          control={
+            <div className="flex items-center gap-3">
+              <select
+                id="settings-theme"
+                name="theme"
+                className="bg-background text-foreground focus-visible:ring-ring focus-visible:ring-offset-background inline-flex h-10 flex-1 items-center rounded-md border px-3 text-sm shadow-sm"
+                value={theme}
+                onChange={handleThemeChange}
+              >
+                {THEME_PREFERENCE_VALUES.map((preference) => (
+                  <option key={preference} value={preference}>
+                    {THEME_LABEL_MAP[preference]}
+                  </option>
+                ))}
+              </select>
+            </div>
+          }
+        />
+
+        <Fieldset
+          label="언어"
+          controlId="settings-language"
+          control={
+            <div className="flex items-center gap-3">
+              <select
+                id="settings-language"
+                name="language"
+                className="bg-background text-foreground focus-visible:ring-ring focus-visible:ring-offset-background inline-flex h-10 flex-1 items-center rounded-md border px-3 text-sm shadow-sm"
+                value={language}
+                onChange={handleLanguageChange}
+              >
+                {LANGUAGE_PREFERENCE_VALUES.map((preference) => (
+                  <option key={preference} value={preference}>
+                    {LANGUAGE_LABEL_MAP[preference]}
+                  </option>
+                ))}
+              </select>
+            </div>
+          }
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+interface FieldsetProps {
+  label: string;
+  controlId: string;
+  description?: string;
+  control: React.ReactNode;
+}
+
+function Fieldset({ label, description, controlId, control }: FieldsetProps) {
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <label
+        htmlFor={controlId}
+        className="text-foreground text-sm font-medium"
+      >
+        {label}
+      </label>
+      {control}
+      <p className="text-muted-foreground text-xs">{description}</p>
+    </fieldset>
+  );
+}

--- a/src/widgets/settings-profile/ui/settings-profile-card.tsx
+++ b/src/widgets/settings-profile/ui/settings-profile-card.tsx
@@ -1,0 +1,123 @@
+import { ExternalLink } from "lucide-react";
+import type {
+  SettingsConnections,
+  SettingsProfile,
+} from "@/entities/settings/model/types";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/shared/ui/card";
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/utils";
+
+interface SettingsProfileCardProps {
+  profile: SettingsProfile;
+  connections: SettingsConnections;
+}
+
+function resolveInitials(profile: SettingsProfile): string {
+  const label = profile.displayName ?? profile.username ?? "?";
+  return label
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function SettingsProfileCard({
+  profile,
+  connections,
+}: SettingsProfileCardProps) {
+  const initials = resolveInitials(profile);
+  const github = connections.github;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>계정 정보</CardTitle>
+        <CardDescription>계정 세부 정보를 표시합니다.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex items-center gap-4">
+          {renderAvatar(profile.avatarUrl, initials)}
+          <div className="space-y-1">
+            <p className="text-foreground text-lg font-semibold">
+              {profile.displayName ?? profile.username}
+            </p>
+            <p className="text-muted-foreground text-sm">@{profile.username}</p>
+          </div>
+        </div>
+
+        <dl className="grid gap-4 text-sm sm:grid-cols-2">
+          {renderProfileField("이메일", profile.email ?? "-")}
+          {renderProfileField("사용자 ID", profile.userId)}
+        </dl>
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-4 border-t pt-6">
+        <div className="flex w-full items-center justify-between gap-4">
+          <div>
+            <p className="text-foreground text-sm font-semibold">GitHub 연동</p>
+          </div>
+          <Badge
+            variant={github?.connected ? "secondary" : "outline"}
+            className={cn(
+              "text-xs",
+              github?.connected
+                ? "bg-emerald-500/10 text-emerald-600"
+                : undefined
+            )}
+          >
+            {github?.connected ? "연결됨" : "미연결"}
+          </Badge>
+        </div>
+        {github?.profileUrl ? (
+          <Button variant="outline" size="sm" className="gap-2" asChild>
+            <a href={github.profileUrl} target="_blank" rel="noreferrer">
+              GitHub 프로필 열기
+              <ExternalLink className="size-3.5" aria-hidden />
+            </a>
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" disabled>
+            연동 정보가 없습니다
+          </Button>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}
+
+function renderProfileField(label: string, value: string) {
+  return (
+    <div key={label} className="space-y-1">
+      <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        {label}
+      </dt>
+      <dd className="text-foreground text-sm font-semibold">{value}</dd>
+    </div>
+  );
+}
+
+function renderAvatar(media: string | undefined, fallback: string) {
+  return (
+    <div className="bg-muted text-muted-foreground flex size-16 items-center justify-center overflow-hidden rounded-full border">
+      {media ? (
+        <img
+          src={media}
+          alt="사용자 아바타"
+          className="size-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <span className="text-base font-semibold">{fallback}</span>
+      )}
+    </div>
+  );
+}

--- a/src/widgets/settings-profile/ui/settings-profile-card.tsx
+++ b/src/widgets/settings-profile/ui/settings-profile-card.tsx
@@ -1,4 +1,3 @@
-import { ExternalLink } from "lucide-react";
 import type {
   SettingsConnections,
   SettingsProfile,
@@ -11,33 +10,19 @@ import {
   CardHeader,
   CardTitle,
 } from "@/shared/ui/card";
-import { Badge } from "@/shared/ui/badge";
-import { Button } from "@/shared/ui/button";
-import { cn } from "@/shared/lib/utils";
+import { ProfileIdentity } from "@/features/settings/ui/profile-identity";
+import { GithubConnection } from "@/features/settings/ui/github-connection";
+import { ProfileFieldList } from "@/features/settings/ui/profile-field-list";
 
 interface SettingsProfileCardProps {
   profile: SettingsProfile;
   connections: SettingsConnections;
 }
 
-function resolveInitials(profile: SettingsProfile): string {
-  const label = profile.displayName ?? profile.username ?? "?";
-  return label
-    .split(" ")
-    .filter(Boolean)
-    .map((part) => part[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
-}
-
 export function SettingsProfileCard({
   profile,
   connections,
 }: SettingsProfileCardProps) {
-  const initials = resolveInitials(profile);
-  const github = connections.github;
-
   return (
     <Card>
       <CardHeader>
@@ -45,79 +30,17 @@ export function SettingsProfileCard({
         <CardDescription>계정 세부 정보를 표시합니다.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="flex items-center gap-4">
-          {renderAvatar(profile.avatarUrl, initials)}
-          <div className="space-y-1">
-            <p className="text-foreground text-lg font-semibold">
-              {profile.displayName ?? profile.username}
-            </p>
-            <p className="text-muted-foreground text-sm">@{profile.username}</p>
-          </div>
-        </div>
-
-        <dl className="grid gap-4 text-sm sm:grid-cols-2">
-          {renderProfileField("이메일", profile.email ?? "-")}
-          {renderProfileField("사용자 ID", profile.userId)}
-        </dl>
+        <ProfileIdentity profile={profile} />
+        <ProfileFieldList
+          fields={[
+            { label: "이메일", value: profile.email ?? "-" },
+            { label: "사용자 ID", value: profile.userId },
+          ]}
+        />
       </CardContent>
-      <CardFooter className="flex flex-col items-start gap-4 border-t pt-6">
-        <div className="flex w-full items-center justify-between gap-4">
-          <div>
-            <p className="text-foreground text-sm font-semibold">GitHub 연동</p>
-          </div>
-          <Badge
-            variant={github?.connected ? "secondary" : "outline"}
-            className={cn(
-              "text-xs",
-              github?.connected
-                ? "bg-emerald-500/10 text-emerald-600"
-                : undefined
-            )}
-          >
-            {github?.connected ? "연결됨" : "미연결"}
-          </Badge>
-        </div>
-        {github?.profileUrl ? (
-          <Button variant="outline" size="sm" className="gap-2" asChild>
-            <a href={github.profileUrl} target="_blank" rel="noreferrer">
-              GitHub 프로필 열기
-              <ExternalLink className="size-3.5" aria-hidden />
-            </a>
-          </Button>
-        ) : (
-          <Button variant="outline" size="sm" disabled>
-            연동 정보가 없습니다
-          </Button>
-        )}
+      <CardFooter className="border-t pt-6">
+        <GithubConnection connections={connections} />
       </CardFooter>
     </Card>
-  );
-}
-
-function renderProfileField(label: string, value: string) {
-  return (
-    <div key={label} className="space-y-1">
-      <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-        {label}
-      </dt>
-      <dd className="text-foreground text-sm font-semibold">{value}</dd>
-    </div>
-  );
-}
-
-function renderAvatar(media: string | undefined, fallback: string) {
-  return (
-    <div className="bg-muted text-muted-foreground flex size-16 items-center justify-center overflow-hidden rounded-full border">
-      {media ? (
-        <img
-          src={media}
-          alt="사용자 아바타"
-          className="size-full object-cover"
-          loading="lazy"
-        />
-      ) : (
-        <span className="text-base font-semibold">{fallback}</span>
-      )}
-    </div>
   );
 }


### PR DESCRIPTION
- [x] 설정,임베딩 api msw 모킹
- [x] 설정 정보 (현재 유저 정보, 로그아웃, 테마/언어 쿠키 저장)
- [x] 임베딩 미리보기 (/render?userId=...&size=..., 현재 착용중인 장비 (이미지, 스탯), 최고층, 스탯 표시)
- [x] 대시보드/설정 임베딩 배너 공통화 및 장비·스탯 공용 컴포넌트 도입
- [x] 테마/언어 Select 및 프로필 카드 FSD 구조 정리 (shadcn Select/Progress 적용)
- [x] 인벤토리 슬롯 UI를 엔티티 레벨 공용 슬롯 그리드로 재구성