### PR TITLE
feat(#49): embed-renderer maxHp 장비 옵션 지원

### DIFF
--- a/packages/embed-renderer/src/lib/stat-format.ts
+++ b/packages/embed-renderer/src/lib/stat-format.ts
@@ -2,6 +2,7 @@ import type { StatTone } from "../types";
 
 const STAT_LABEL_MAP: Record<string, string> = {
   hp: "HP",
+  maxHp: "MAX HP",
   atk: "ATK",
   def: "DEF",
   luck: "LUCK",

--- a/packages/embed-renderer/src/types.ts
+++ b/packages/embed-renderer/src/types.ts
@@ -16,7 +16,7 @@ export type EquipmentRarity =
   | "epic"
   | "legendary";
 
-export type EquipmentStat = "hp" | "atk" | "def" | "luck" | "ap";
+export type EquipmentStat = "hp" | "maxHp" | "atk" | "def" | "luck" | "ap";
 
 export interface EquipmentModifier {
   stat: EquipmentStat;


### PR DESCRIPTION
## 개요

embed-renderer의 장비 스탯 타입에 `maxHp`를 추가해 BE 타입과의 불일치를 해결한다.

## 변경 사항

- `packages/embed-renderer/src/types.ts`: `EquipmentStat`에 `maxHp` 추가
- `packages/embed-renderer/src/lib/stat-format.ts`: `maxHp` 라벨 매핑 추가

## 테스트

- [x] 유닛 테스트 통과 (`pnpm test`)
- [x] 통합 테스트 완료 (`pnpm --filter "@git-dungeon/embed-renderer" build`)

## 관련 문서

- Spec: `docs/features/fe/F020-embed-renderer-hotfix/spec.md`
- Tasks: `docs/features/fe/F020-embed-renderer-hotfix/tasks.md`

Closes #49


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 최대 체력(MAX HP) 통계가 장비 시스템에 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->