### PR TITLE
feat(#67): 로그/인벤토리 UI 리팩터링

### DIFF
--- a/src/entities/dungeon-log/config/thumbnails.test.ts
+++ b/src/entities/dungeon-log/config/thumbnails.test.ts
@@ -55,7 +55,7 @@ describe("buildLogThumbnails", () => {
     expect(thumbnails.map((thumbnail) => thumbnail.id)).toEqual([
       "log-battle-order-action",
       "log-battle-order-monster",
-      "log-battle-order-reward-item",
+      "log-battle-order-reward-item-1",
       "log-battle-order-gold",
     ]);
   });
@@ -82,8 +82,39 @@ describe("buildLogThumbnails", () => {
     const thumbnails = buildLogThumbnails(entry);
     expect(thumbnails.map((thumbnail) => thumbnail.id)).toEqual([
       "log-treasure-order-action",
-      "log-treasure-order-reward-item",
+      "log-treasure-order-reward-item-1",
       "log-treasure-order-gold",
+    ]);
+  });
+
+  it("BATTLE 보상 아이템이 여러 개면 썸네일을 모두 추가한다", () => {
+    const entry: DungeonLogEntry = {
+      id: "log-battle-multi-reward",
+      category: "EXPLORATION",
+      floor: 1,
+      action: "BATTLE",
+      status: "COMPLETED",
+      createdAt: "2025-12-01T00:00:00Z",
+      delta: {
+        type: "BATTLE",
+        detail: {
+          rewards: {
+            gold: 5,
+            items: [
+              { code: "ring-copper-band", quantity: 1 },
+              { code: "ring-silver-band", quantity: 1 },
+            ],
+          },
+        },
+      },
+    };
+
+    const thumbnails = buildLogThumbnails(entry);
+    expect(thumbnails.map((thumbnail) => thumbnail.id)).toEqual([
+      "log-battle-multi-reward-action",
+      "log-battle-multi-reward-reward-item-1",
+      "log-battle-multi-reward-reward-item-2",
+      "log-battle-multi-reward-gold",
     ]);
   });
 });

--- a/src/entities/dungeon-log/config/thumbnails.ts
+++ b/src/entities/dungeon-log/config/thumbnails.ts
@@ -183,6 +183,7 @@ export function buildLogThumbnails(
       return false;
     }
 
+    let pushed = false;
     items.forEach((item, index) => {
       const itemThumbnail = resolveItemThumbnail(item.code);
       if (!itemThumbnail) {
@@ -197,8 +198,9 @@ export function buildLogThumbnails(
         badge,
         rarity,
       });
+      pushed = true;
     });
-    return true;
+    return pushed;
   };
 
   if (actionThumbnail && (isBattleAction || isTreasureAction)) {

--- a/src/entities/dungeon-log/config/thumbnails.ts
+++ b/src/entities/dungeon-log/config/thumbnails.ts
@@ -18,6 +18,8 @@ import type { EquipmentRarity } from "@/entities/inventory/model/types";
 import type {
   DungeonLogEntry,
   DungeonLogAction,
+  DungeonLogInventoryDeltaItem,
+  DungeonLogRewardItem,
 } from "@/entities/dungeon-log/model/types";
 
 export type LogThumbnailBadge = "gain" | "loss";
@@ -152,6 +154,52 @@ export function buildLogThumbnails(
   const actionThumbnail = resolveActionThumbnail(entry.action);
   const isBattleAction = entry.action === "BATTLE";
   const isTreasureAction = entry.action === "TREASURE";
+  const pushRewardItems = (items?: DungeonLogRewardItem[]) => {
+    if (!items?.length) {
+      return;
+    }
+
+    items.forEach((rewardItem, index) => {
+      const itemThumbnail = resolveItemThumbnail(rewardItem.code);
+      if (!itemThumbnail) {
+        return;
+      }
+      const itemName = resolveName(rewardItem.code);
+      const rarity = resolveRarity(rewardItem.code);
+      thumbnails.push({
+        id: `${entry.id}-reward-item-${index + 1}`,
+        src: itemThumbnail,
+        alt: itemName ?? t("logs.thumbnails.rewardItem"),
+        badge: "gain",
+        rarity,
+      });
+    });
+  };
+  const pushInventoryItems = (
+    items: DungeonLogInventoryDeltaItem[] | undefined,
+    badge: LogThumbnailBadge
+  ) => {
+    if (!items?.length) {
+      return false;
+    }
+
+    items.forEach((item, index) => {
+      const itemThumbnail = resolveItemThumbnail(item.code);
+      if (!itemThumbnail) {
+        return;
+      }
+      const itemName = resolveName(item.code);
+      const rarity = resolveRarity(item.code, item.rarity);
+      thumbnails.push({
+        id: `${entry.id}-item-${index + 1}`,
+        src: itemThumbnail,
+        alt: itemName ?? t("logs.thumbnails.item"),
+        badge,
+        rarity,
+      });
+    });
+    return true;
+  };
 
   if (actionThumbnail && (isBattleAction || isTreasureAction)) {
     thumbnails.push({
@@ -182,30 +230,41 @@ export function buildLogThumbnails(
   const delta = entry.delta;
 
   if (delta?.type === "BATTLE") {
-    const rewardItem = delta.detail.rewards?.items?.at(0);
-    const itemThumbnail = resolveItemThumbnail(rewardItem?.code);
-    if (itemThumbnail) {
-      const itemName = rewardItem?.code
-        ? resolveName(rewardItem.code)
-        : undefined;
-      const rarity = rewardItem?.code
-        ? resolveRarity(rewardItem.code)
-        : undefined;
-      thumbnails.push({
-        id: `${entry.id}-reward-item`,
-        src: itemThumbnail,
-        alt: itemName ?? t("logs.thumbnails.rewardItem"),
-        badge: "gain",
-        rarity,
-      });
+    pushRewardItems(delta.detail.rewards?.items);
+  }
+
+  if (delta?.type === "ACQUIRE_ITEM") {
+    const inventory = delta.detail.inventory;
+    if (!pushInventoryItems(inventory.added, "gain")) {
+      const primaryItem =
+        inventory.equipped ??
+        inventory.unequipped ??
+        inventory.added?.at(0) ??
+        inventory.removed?.at(0);
+
+      const itemKey = primaryItem?.code;
+      const itemThumbnail = resolveItemThumbnail(itemKey);
+      if (itemThumbnail) {
+        const itemName = itemKey ? resolveName(itemKey) : undefined;
+        const rarity =
+          itemKey && primaryItem
+            ? resolveRarity(itemKey, primaryItem.rarity)
+            : undefined;
+        thumbnails.push({
+          id: `${entry.id}-item`,
+          src: itemThumbnail,
+          alt: itemName ?? t("logs.thumbnails.item"),
+          badge: "gain",
+          rarity,
+        });
+      }
     }
   }
 
   if (
     delta?.type === "EQUIP_ITEM" ||
     delta?.type === "UNEQUIP_ITEM" ||
-    delta?.type === "DISCARD_ITEM" ||
-    delta?.type === "ACQUIRE_ITEM"
+    delta?.type === "DISCARD_ITEM"
   ) {
     const inventory = delta.detail.inventory;
     const primaryItem =
@@ -237,23 +296,7 @@ export function buildLogThumbnails(
   }
 
   if (delta?.type === "TREASURE") {
-    const rewardItem = delta.detail.rewards?.items?.at(0);
-    const itemThumbnail = resolveItemThumbnail(rewardItem?.code);
-    if (itemThumbnail) {
-      const itemName = rewardItem?.code
-        ? resolveName(rewardItem.code)
-        : undefined;
-      const rarity = rewardItem?.code
-        ? resolveRarity(rewardItem.code)
-        : undefined;
-      thumbnails.push({
-        id: `${entry.id}-reward-item`,
-        src: itemThumbnail,
-        alt: itemName ?? t("logs.thumbnails.rewardItem"),
-        badge: "gain",
-        rarity,
-      });
-    }
+    pushRewardItems(delta.detail.rewards?.items);
   }
 
   if (actionThumbnail && !isBattleAction && !isTreasureAction) {

--- a/src/index.css
+++ b/src/index.css
@@ -737,10 +737,20 @@
   }
 
   .inventory-item__icon {
-    background-color: var(--rarity-bg, rgba(107, 114, 128, 0.2));
+    position: relative;
+    background-color: var(--pixel-surface-deep);
     border: 2px solid var(--rarity-border, var(--border));
-    border-radius: 8px;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    border-radius: 0;
+    clip-path: polygon(
+      3px 0,
+      calc(100% - 3px) 0,
+      100% 3px,
+      100% calc(100% - 3px),
+      calc(100% - 3px) 100%,
+      3px 100%,
+      0 calc(100% - 3px),
+      0 3px
+    );
   }
 
   .rarity-common {
@@ -1335,7 +1345,7 @@
 
   .pixel-app .pixel-log-thumb {
     border: 2px solid var(--rarity-border, var(--pixel-border-strong));
-    background: var(--rarity-bg, var(--pixel-surface-deep));
+    background: var(--pixel-surface-deep);
     border-radius: 0;
     box-shadow:
       inset 0 0 0 1px rgba(255, 255, 255, 0.12),

--- a/src/shared/ui/pixel-check-icon.tsx
+++ b/src/shared/ui/pixel-check-icon.tsx
@@ -2,26 +2,56 @@ import type { HTMLAttributes } from "react";
 import { cn } from "@/shared/lib/utils";
 import { PixelIcon } from "@/shared/ui/pixel-icon";
 
+type PixelCheckIconTone = "gain" | "loss";
+
 interface PixelCheckIconProps extends HTMLAttributes<HTMLSpanElement> {
   checked?: boolean;
+  size?: number;
+  iconSize?: number;
+  tone?: PixelCheckIconTone;
 }
 
 export function PixelCheckIcon({
   checked = true,
+  size,
+  iconSize,
+  tone,
   className,
+  style,
   ...props
 }: PixelCheckIconProps) {
   if (!checked) {
     return null;
   }
 
+  const resolvedIconSize = iconSize ?? (size ? Math.round(size * 0.66) : 12);
+  const mergedStyle = size ? { width: size, height: size, ...style } : style;
+
+  const toneClass =
+    tone === "gain"
+      ? "pixel-log-thumb__badge--gain"
+      : tone === "loss"
+        ? "pixel-log-thumb__badge--loss"
+        : undefined;
+
   return (
     <span
       aria-hidden="true"
-      className={cn("pixel-checkbox", "pixel-checkbox--checked", className)}
+      className={cn(
+        "pixel-checkbox",
+        "pixel-checkbox--checked",
+        toneClass,
+        className
+      )}
+      style={mergedStyle}
       {...props}
     >
-      <PixelIcon name="check" className="pixel-checkbox__icon" />
+      <PixelIcon
+        name="check"
+        size={resolvedIconSize}
+        className="pixel-checkbox__icon"
+        style={{ width: resolvedIconSize, height: resolvedIconSize }}
+      />
     </span>
   );
 }

--- a/src/widgets/dungeon-log-timeline/ui/dungeon-log-timeline.stories.tsx
+++ b/src/widgets/dungeon-log-timeline/ui/dungeon-log-timeline.stories.tsx
@@ -4,7 +4,10 @@ import type { InfiniteData } from "@tanstack/react-query";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { DungeonLogTimeline } from "@/widgets/dungeon-log-timeline/ui/dungeon-log-timeline";
 import { DUNGEON_LOGS_PAGE_SIZE } from "@/widgets/dungeon-log-timeline/config/constants";
-import type { DungeonLogsPayload } from "@/entities/dungeon-log/model/types";
+import type {
+  DungeonLogEntry,
+  DungeonLogsPayload,
+} from "@/entities/dungeon-log/model/types";
 import { sampleDungeonLogs } from "@/mocks/fixtures/storybook";
 
 const withLogData: Decorator = (Story) => <LogDataProvider Story={Story} />;
@@ -32,10 +35,64 @@ function LogDataProvider({ Story }: { Story: () => ReactElement }) {
       },
     ] as const;
 
+    const storyLogs: DungeonLogEntry[] = sampleDungeonLogs.map((log) => {
+      if (log.delta?.type === "BATTLE") {
+        const rewards = log.delta.detail.rewards ?? {};
+        const items = rewards.items ?? [];
+        return {
+          ...log,
+          delta: {
+            ...log.delta,
+            detail: {
+              ...log.delta.detail,
+              rewards: {
+                ...rewards,
+                items: [
+                  ...items,
+                  {
+                    code: "ring-silver-band",
+                    quantity: 1,
+                  },
+                ],
+              },
+            },
+          },
+        };
+      }
+
+      if (log.delta?.type === "ACQUIRE_ITEM") {
+        const inventory = log.delta.detail.inventory;
+        const addedItems = inventory.added ?? [];
+        return {
+          ...log,
+          delta: {
+            ...log.delta,
+            detail: {
+              ...log.delta.detail,
+              inventory: {
+                ...inventory,
+                added: [
+                  ...addedItems,
+                  {
+                    itemId: "inv-004-bonus",
+                    code: "weapon-short-sword",
+                    slot: "weapon",
+                    quantity: 1,
+                  },
+                ],
+              },
+            },
+          },
+        };
+      }
+
+      return log;
+    });
+
     const payload: InfiniteData<DungeonLogsPayload> = {
       pages: [
         {
-          logs: sampleDungeonLogs.slice(0, DUNGEON_LOGS_PAGE_SIZE),
+          logs: storyLogs.slice(0, DUNGEON_LOGS_PAGE_SIZE),
           nextCursor: null,
         },
       ],

--- a/src/widgets/inventory/ui/inventory-grid.tsx
+++ b/src/widgets/inventory/ui/inventory-grid.tsx
@@ -101,6 +101,8 @@ function InventoryGridCell({
       {item.isEquipped ? (
         <PixelCheckIcon
           className="absolute top-1 left-1"
+          size={24}
+          tone="gain"
           title={t("inventory.grid.equipped")}
         />
       ) : null}


### PR DESCRIPTION
## 개요

로그 보상/획득 썸네일 다중 표시와 인벤토리 UI 가독성 개선을 반영했습니다.

## 변경 사항

- 로그 보상/획득 아이템 썸네일을 다중 렌더링하도록 개선
- PixelCheckIcon tone prop 추가 및 인벤토리 착용 체크 표시 개선
- 희귀도 배경 제거 및 인벤토리 아이템 테두리 픽셀 모서리 적용
- DungeonLogTimeline 스토리에 다중 아이템 케이스 추가
- ACQUIRE_ITEM 썸네일 추가 여부 기준 보정

## 테스트

- [x] 유닛 테스트 통과
- [x] 통합 테스트 완료

## 스크린샷 (UI 변경 시)

없음

## 관련 문서

- Spec: `docs/features/fe/F032-logs-inventory-ui-refactor/spec.md`
- Tasks: `docs/features/fe/F032-logs-inventory-ui-refactor/tasks.md`

Closes #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 던전 로그의 보상 아이템이 각각 별도 썸네일(항목별 인덱스 포함)로 표시됩니다.
  * 장착된 인벤토리 아이템에 크기 및 톤이 반영된 체크 아이콘이 표시됩니다.

* **스타일**
  * 인벤토리 아이콘의 외형(모양·배경 처리)이 픽셀 스타일로 변경되었습니다.

* **테스트**
  * 보상 아이템 썸네일 생성 로직에 대한 테스트가 추가/갱신되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->