### PR TITLE
feat(#71): 랭킹 페이지

### DIFF
--- a/src/entities/ranking/api/get-ranking.test.ts
+++ b/src/entities/ranking/api/get-ranking.test.ts
@@ -1,0 +1,60 @@
+import { http } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import { server } from "@/mocks/tests/server";
+import { respondWithError, respondWithSuccess } from "@/mocks/lib/api-response";
+import { RANKING_ENDPOINTS } from "@/shared/config/env";
+import { getRanking } from "@/entities/ranking/api/get-ranking";
+import * as httpClient from "@/shared/api/http-client";
+import { createAppError } from "@/shared/errors/app-error";
+
+const rankingPayload = {
+  rankings: [
+    {
+      rank: 1,
+      displayName: "PixelHero",
+      avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+      level: 25,
+      maxFloor: 30,
+    },
+  ],
+  nextCursor: null,
+} as const;
+
+describe("getRanking", () => {
+  it("랭킹 목록을 스키마로 파싱한다", async () => {
+    server.use(
+      http.get(RANKING_ENDPOINTS.list, () => respondWithSuccess(rankingPayload))
+    );
+
+    await expect(getRanking()).resolves.toEqual(rankingPayload);
+  });
+
+  it("API 오류 응답 시 AppError를 던진다", async () => {
+    server.use(
+      http.get(RANKING_ENDPOINTS.list, () =>
+        respondWithError("RANKING_INVALID_QUERY", {
+          status: 400,
+          code: "RANKING_INVALID_QUERY",
+        })
+      )
+    );
+
+    await expect(getRanking()).rejects.toMatchObject({
+      name: "AppError",
+    });
+  });
+
+  it("네트워크 오류 시 AppError로 전달한다", async () => {
+    const requestWithSchemaSpy = vi
+      .spyOn(httpClient, "requestWithSchema")
+      .mockRejectedValueOnce(
+        createAppError("NETWORK_FAILED", "Network request failed")
+      );
+
+    await expect(getRanking()).rejects.toMatchObject({
+      code: "NETWORK_FAILED",
+    });
+
+    requestWithSchemaSpy.mockRestore();
+  });
+});

--- a/src/entities/ranking/api/get-ranking.ts
+++ b/src/entities/ranking/api/get-ranking.ts
@@ -1,0 +1,32 @@
+import { requestWithSchema } from "@/shared/api/http-client";
+import { RANKING_ENDPOINTS } from "@/shared/config/env";
+import {
+  rankingListSchema,
+  type RankingList,
+} from "@/entities/ranking/model/types";
+
+export interface FetchRankingParams {
+  limit?: number;
+  cursor?: string;
+}
+
+export async function getRanking(
+  params: FetchRankingParams = {}
+): Promise<RankingList> {
+  const { limit, cursor } = params;
+  const searchParams = new URLSearchParams();
+
+  if (typeof limit === "number") {
+    searchParams.set("limit", limit.toString());
+  }
+
+  if (cursor) {
+    searchParams.set("cursor", cursor);
+  }
+
+  const endpoint = searchParams.size
+    ? `${RANKING_ENDPOINTS.list}?${searchParams.toString()}`
+    : RANKING_ENDPOINTS.list;
+
+  return requestWithSchema(endpoint, rankingListSchema);
+}

--- a/src/entities/ranking/model/ranking-query.ts
+++ b/src/entities/ranking/model/ranking-query.ts
@@ -1,0 +1,21 @@
+import { queryOptions } from "@tanstack/react-query";
+import {
+  getRanking,
+  type FetchRankingParams,
+} from "@/entities/ranking/api/get-ranking";
+
+export const RANKING_QUERY_KEY = ["ranking"] as const;
+
+export function rankingQueryOptions(params: FetchRankingParams = {}) {
+  const { limit, cursor } = params;
+
+  return queryOptions({
+    queryKey: [
+      ...RANKING_QUERY_KEY,
+      { limit: limit ?? null, cursor: cursor ?? null },
+    ] as const,
+    queryFn: () => getRanking({ limit, cursor }),
+    staleTime: 1000 * 60,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/entities/ranking/model/types.ts
+++ b/src/entities/ranking/model/types.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const rankingEntrySchema = z.object({
+  rank: z.number().int(),
+  displayName: z.string().nullable().optional(),
+  avatarUrl: z.string().url().nullable().optional(),
+  level: z.number().int(),
+  maxFloor: z.number().int(),
+});
+
+export const rankingListSchema = z.object({
+  rankings: z.array(rankingEntrySchema),
+  nextCursor: z.string().nullable().optional(),
+});
+
+export type RankingEntry = z.infer<typeof rankingEntrySchema>;
+export type RankingList = z.infer<typeof rankingListSchema>;

--- a/src/entities/ranking/model/use-infinite-ranking.ts
+++ b/src/entities/ranking/model/use-infinite-ranking.ts
@@ -1,0 +1,22 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+  getRanking,
+  type FetchRankingParams,
+} from "@/entities/ranking/api/get-ranking";
+
+export const RANKING_DEFAULT_LIMIT = 10;
+
+export function useInfiniteRanking(params: FetchRankingParams = {}) {
+  const limit = params.limit ?? RANKING_DEFAULT_LIMIT;
+
+  return useInfiniteQuery({
+    queryKey: ["ranking", "infinite", { limit }] as const,
+    queryFn: ({ pageParam }) =>
+      getRanking({
+        limit,
+        cursor: pageParam ?? undefined,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/src/features/ranking-list/model/use-ranking-list.ts
+++ b/src/features/ranking-list/model/use-ranking-list.ts
@@ -36,3 +36,5 @@ export function useRankingList(params: UseRankingListParams = {}) {
     refetch,
   };
 }
+
+export type RankingListState = ReturnType<typeof useRankingList>;

--- a/src/mocks/fixtures/ranking.ts
+++ b/src/mocks/fixtures/ranking.ts
@@ -1,0 +1,28 @@
+import type { RankingList } from "@/entities/ranking/model/types";
+
+export const rankingFixture: RankingList = {
+  rankings: [
+    {
+      rank: 1,
+      displayName: "PixelHero",
+      avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+      level: 25,
+      maxFloor: 30,
+    },
+    {
+      rank: 2,
+      displayName: "CodeMage",
+      avatarUrl: "https://avatars.githubusercontent.com/u/2?v=4",
+      level: 24,
+      maxFloor: 28,
+    },
+    {
+      rank: 3,
+      displayName: "ShadowByte",
+      avatarUrl: null,
+      level: 23,
+      maxFloor: 27,
+    },
+  ],
+  nextCursor: "MTI=",
+};

--- a/src/mocks/handlers/handlers.ts
+++ b/src/mocks/handlers/handlers.ts
@@ -6,6 +6,7 @@ import { settingsHandlers } from "./settings-handlers";
 import { embedHandlers } from "./embed-handlers";
 import { catalogHandlers } from "./catalog-handlers";
 import { githubHandlers } from "./github-handlers";
+import { rankingHandlers } from "./ranking-handlers";
 
 export const handlers = [
   ...authHandlers,
@@ -16,4 +17,5 @@ export const handlers = [
   ...catalogHandlers,
   ...githubHandlers,
   ...embedHandlers,
+  ...rankingHandlers,
 ];

--- a/src/mocks/handlers/ranking-handlers.ts
+++ b/src/mocks/handlers/ranking-handlers.ts
@@ -1,0 +1,8 @@
+import { http } from "msw";
+import { respondWithSuccess } from "@/mocks/lib/api-response";
+import { RANKING_ENDPOINTS } from "@/shared/config/env";
+import { rankingFixture } from "@/mocks/fixtures/ranking";
+
+export const rankingHandlers = [
+  http.get(RANKING_ENDPOINTS.list, () => respondWithSuccess(rankingFixture)),
+];

--- a/src/pages/ranking/ui/ranking-page.test.tsx
+++ b/src/pages/ranking/ui/ranking-page.test.tsx
@@ -1,6 +1,7 @@
 import React, { StrictMode, act } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RankingPage } from "./ranking-page";
 
 const rankingTableSpy = vi.fn();
@@ -16,9 +17,14 @@ function render(ui: React.ReactElement) {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
+  const queryClient = new QueryClient();
 
   act(() => {
-    root.render(<StrictMode>{ui}</StrictMode>);
+    root.render(
+      <StrictMode>
+        <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+      </StrictMode>
+    );
   });
 
   return {

--- a/src/pages/ranking/ui/ranking-page.test.tsx
+++ b/src/pages/ranking/ui/ranking-page.test.tsx
@@ -1,0 +1,50 @@
+import React, { StrictMode, act } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createRoot } from "react-dom/client";
+import { RankingPage } from "./ranking-page";
+
+const rankingTableSpy = vi.fn();
+
+vi.mock("@/widgets/ranking-table/ui/ranking-table", () => ({
+  RankingTable: () => {
+    rankingTableSpy();
+    return <div data-testid="ranking-table" />;
+  },
+}));
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(<StrictMode>{ui}</StrictMode>);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+beforeAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+describe("/ranking 화면", () => {
+  it("RankingTable을 렌더링한다", () => {
+    const { container, unmount } = render(<RankingPage />);
+
+    expect(
+      container.querySelector("[data-testid='ranking-table']")
+    ).not.toBeNull();
+    expect(rankingTableSpy).toHaveBeenCalled();
+
+    unmount();
+  });
+});

--- a/src/pages/ranking/ui/ranking-page.tsx
+++ b/src/pages/ranking/ui/ranking-page.tsx
@@ -1,11 +1,17 @@
+import { useTranslation } from "react-i18next";
 import { RankingTable } from "@/widgets/ranking-table/ui/ranking-table";
 
 export function RankingPage() {
+  const { t } = useTranslation();
+
   return (
     <section className="space-y-6">
       <header>
-        <h1 className="font-pixel-title pixel-page-title" data-text="RANKING">
-          RANKING
+        <h1
+          className="font-pixel-title pixel-page-title"
+          data-text={t("ranking.title")}
+        >
+          {t("ranking.title")}
         </h1>
       </header>
       <RankingTable />

--- a/src/pages/ranking/ui/ranking-page.tsx
+++ b/src/pages/ranking/ui/ranking-page.tsx
@@ -7,7 +7,7 @@ export function RankingPage() {
   const rankingList = useRankingList();
 
   return (
-    <section className="space-y-6">
+    <section className="flex min-h-[calc(100svh-var(--pixel-page-offset))] flex-col gap-6">
       <header>
         <h1
           className="font-pixel-title pixel-page-title"

--- a/src/pages/ranking/ui/ranking-page.tsx
+++ b/src/pages/ranking/ui/ranking-page.tsx
@@ -1,0 +1,14 @@
+import { RankingTable } from "@/widgets/ranking-table/ui/ranking-table";
+
+export function RankingPage() {
+  return (
+    <section className="space-y-6">
+      <header>
+        <h1 className="font-pixel-title pixel-page-title" data-text="RANKING">
+          RANKING
+        </h1>
+      </header>
+      <RankingTable />
+    </section>
+  );
+}

--- a/src/pages/ranking/ui/ranking-page.tsx
+++ b/src/pages/ranking/ui/ranking-page.tsx
@@ -1,8 +1,10 @@
 import { useTranslation } from "react-i18next";
 import { RankingTable } from "@/widgets/ranking-table/ui/ranking-table";
+import { useRankingList } from "@/features/ranking-list/model/use-ranking-list";
 
 export function RankingPage() {
   const { t } = useTranslation();
+  const rankingList = useRankingList();
 
   return (
     <section className="space-y-6">
@@ -14,7 +16,7 @@ export function RankingPage() {
           {t("ranking.title")}
         </h1>
       </header>
-      <RankingTable />
+      <RankingTable {...rankingList} />
     </section>
   );
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as RankingRouteImport } from './routes/ranking'
 import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as LogsRouteImport } from './routes/logs'
 import { Route as LoginRouteImport } from './routes/login'
@@ -20,6 +21,11 @@ import { Route as IndexRouteImport } from './routes/index'
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RankingRoute = RankingRouteImport.update({
+  id: '/ranking',
+  path: '/ranking',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OnboardingRoute = OnboardingRouteImport.update({
@@ -60,6 +66,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/logs': typeof LogsRoute
   '/onboarding': typeof OnboardingRoute
+  '/ranking': typeof RankingRoute
   '/settings': typeof SettingsRoute
 }
 export interface FileRoutesByTo {
@@ -69,6 +76,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/logs': typeof LogsRoute
   '/onboarding': typeof OnboardingRoute
+  '/ranking': typeof RankingRoute
   '/settings': typeof SettingsRoute
 }
 export interface FileRoutesById {
@@ -79,6 +87,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/logs': typeof LogsRoute
   '/onboarding': typeof OnboardingRoute
+  '/ranking': typeof RankingRoute
   '/settings': typeof SettingsRoute
 }
 export interface FileRouteTypes {
@@ -90,6 +99,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/logs'
     | '/onboarding'
+    | '/ranking'
     | '/settings'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -99,6 +109,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/logs'
     | '/onboarding'
+    | '/ranking'
     | '/settings'
   id:
     | '__root__'
@@ -108,6 +119,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/logs'
     | '/onboarding'
+    | '/ranking'
     | '/settings'
   fileRoutesById: FileRoutesById
 }
@@ -118,6 +130,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   LogsRoute: typeof LogsRoute
   OnboardingRoute: typeof OnboardingRoute
+  RankingRoute: typeof RankingRoute
   SettingsRoute: typeof SettingsRoute
 }
 
@@ -128,6 +141,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ranking': {
+      id: '/ranking'
+      path: '/ranking'
+      fullPath: '/ranking'
+      preLoaderRoute: typeof RankingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/onboarding': {
@@ -182,6 +202,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   LogsRoute: LogsRoute,
   OnboardingRoute: OnboardingRoute,
+  RankingRoute: RankingRoute,
   SettingsRoute: SettingsRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import { NotFoundPage } from "@/pages/not-found/ui/not-found-page";
 const NAVIGATION_LINKS = [
   { to: "/dashboard", labelKey: "navigation.dashboard" },
   { to: "/inventory", labelKey: "navigation.inventory" },
+  { to: "/ranking", labelKey: "navigation.ranking" },
   { to: "/logs", labelKey: "navigation.logs" },
   { to: "/settings", labelKey: "navigation.settings" },
 ] as const;

--- a/src/routes/ranking.tsx
+++ b/src/routes/ranking.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { RankingPage } from "@/pages/ranking/ui/ranking-page";
+
+export const Route = createFileRoute("/ranking")({
+  component: RankingRoute,
+});
+
+function RankingRoute() {
+  return <RankingPage />;
+}

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -147,6 +147,10 @@ export const CATALOG_ENDPOINTS = {
   catalog: "/api/catalog",
 } as const;
 
+export const RANKING_ENDPOINTS = {
+  list: "/api/ranking",
+} as const;
+
 export function resolveWebUrl(path: string): string {
   if (/^https?:/i.test(path)) {
     return path;

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -11,7 +11,8 @@
     "dashboard": "Dashboard",
     "inventory": "Inventory",
     "logs": "Logs",
-    "settings": "Settings"
+    "settings": "Settings",
+    "ranking": "Ranking"
   },
   "onboarding": {
     "title": "ONBOARDING",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -583,5 +583,23 @@
     "API_UNAVAILABLE": "Service is unavailable. Please try again later.",
     "UNKNOWN": "An unknown error occurred.",
     "API_PRECONDITION_FAILED": "Request precondition failed."
+  },
+  "ranking": {
+    "title": "Ranking",
+    "table": {
+      "rank": "Rank",
+      "player": "Player",
+      "level": "Level",
+      "highestFloor": "Highest Floor"
+    },
+    "state": {
+      "empty": "No rankings available.",
+      "error": "Failed to load rankings.",
+      "retry": "Retry",
+      "loadingMore": "Loading...",
+      "allLoaded": "All loaded.",
+      "loadMore": "Load more"
+    },
+    "avatarAlt": "Player avatar"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -580,5 +580,23 @@
     "API_UNAVAILABLE": "서비스를 이용할 수 없습니다. 잠시 후 다시 시도해주세요.",
     "UNKNOWN": "알 수 없는 오류가 발생했습니다.",
     "API_PRECONDITION_FAILED": "요청 조건을 만족하지 않습니다."
+  },
+  "ranking": {
+    "title": "랭킹",
+    "table": {
+      "rank": "Rank",
+      "player": "Player",
+      "level": "Level",
+      "highestFloor": "Highest Floor"
+    },
+    "state": {
+      "empty": "표시할 랭킹이 없습니다.",
+      "error": "랭킹 정보를 불러오지 못했습니다.",
+      "retry": "다시 시도",
+      "loadingMore": "불러오는 중...",
+      "allLoaded": "모두 불러왔습니다.",
+      "loadMore": "더 보기"
+    },
+    "avatarAlt": "플레이어 아바타"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -585,10 +585,10 @@
   "ranking": {
     "title": "랭킹",
     "table": {
-      "rank": "Rank",
-      "player": "Player",
-      "level": "Level",
-      "highestFloor": "Highest Floor"
+      "rank": "순위",
+      "player": "플레이어",
+      "level": "레벨",
+      "highestFloor": "최고 층수"
     },
     "state": {
       "empty": "표시할 랭킹이 없습니다.",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -11,7 +11,8 @@
     "dashboard": "대시보드",
     "inventory": "인벤토리",
     "logs": "로그",
-    "settings": "설정"
+    "settings": "설정",
+    "ranking": "랭킹"
   },
   "onboarding": {
     "title": "시작하기",

--- a/src/styles/pixel-theme.css
+++ b/src/styles/pixel-theme.css
@@ -55,7 +55,18 @@
     --ring: #f4c76f;
     --radius: 0.55rem;
     --pixel-container: 1280px;
+    --pixel-header-height: 72px;
+    --pixel-main-padding-top: 28px;
+    --pixel-main-padding-bottom: 40px;
     --pixel-frame-border: 14px;
+    --pixel-frame-border-2: calc(var(--pixel-frame-border) * 2);
+    --pixel-frame-padding: 22px;
+    --pixel-frame-padding-2: calc(var(--pixel-frame-padding) * 2);
+    --pixel-page-offset: calc(
+      var(--pixel-header-height) + var(--pixel-main-padding-top) +
+        var(--pixel-main-padding-bottom) + var(--pixel-frame-padding-2) +
+        var(--pixel-frame-border-2)
+    );
     --pixel-frame-slice: 180;
     --pixel-panel-border: 14px;
     --pixel-panel-slice: 180;
@@ -333,7 +344,7 @@
   }
 
   .pixel-main {
-    padding: 28px 16px 40px;
+    padding: var(--pixel-main-padding-top) 16px var(--pixel-main-padding-bottom);
     display: flex;
     justify-content: center;
   }
@@ -341,7 +352,7 @@
   .pixel-frame {
     width: min(var(--pixel-container), 100%);
     margin: 0 auto;
-    padding: 22px;
+    padding: var(--pixel-frame-padding);
     position: relative;
     border-radius: 0;
     background: var(--pixel-surface-strong);

--- a/src/widgets/ranking-table/model/use-ranking-list.ts
+++ b/src/widgets/ranking-table/model/use-ranking-list.ts
@@ -1,0 +1,38 @@
+import { useMemo } from "react";
+import { useInfiniteRanking } from "@/entities/ranking/model/use-infinite-ranking";
+
+interface UseRankingListParams {
+  limit?: number;
+}
+
+export function useRankingList(params: UseRankingListParams = {}) {
+  const { limit } = params;
+  const query = useInfiniteRanking({ limit });
+
+  const {
+    data,
+    status,
+    error,
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = query;
+
+  const rankings = useMemo(
+    () => data?.pages.flatMap((page) => page.rankings) ?? [],
+    [data]
+  );
+
+  return {
+    rankings,
+    status,
+    error,
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  };
+}

--- a/src/widgets/ranking-table/ui/ranking-table.tsx
+++ b/src/widgets/ranking-table/ui/ranking-table.tsx
@@ -7,12 +7,14 @@ import {
 import { PixelPanel } from "@/shared/ui/pixel-panel";
 import { useRankingList } from "@/widgets/ranking-table/model/use-ranking-list";
 import type { RankingEntry } from "@/entities/ranking/model/types";
+import { useTranslation } from "react-i18next";
 
 interface RankingTableProps {
   limit?: number;
 }
 
 export function RankingTable({ limit = 10 }: RankingTableProps) {
+  const { t } = useTranslation();
   const {
     rankings,
     status,
@@ -33,8 +35,12 @@ export function RankingTable({ limit = 10 }: RankingTableProps) {
 
     return (
       <PixelErrorState
-        message="랭킹 정보를 불러오지 못했습니다."
-        actions={<PixelButton onClick={() => refetch()}>다시 시도</PixelButton>}
+        message={t("ranking.state.error")}
+        actions={
+          <PixelButton onClick={() => refetch()}>
+            {t("ranking.state.retry")}
+          </PixelButton>
+        }
       >
         {message ? <p className="pixel-text-muted text-xs">{message}</p> : null}
       </PixelErrorState>
@@ -42,7 +48,7 @@ export function RankingTable({ limit = 10 }: RankingTableProps) {
   }
 
   if (rankings.length === 0) {
-    return <PixelEmptyState message="표시할 랭킹이 없습니다." />;
+    return <PixelEmptyState message={t("ranking.state.empty")} />;
   }
 
   const isRefreshing = isFetching || isFetchingNextPage;
@@ -53,10 +59,14 @@ export function RankingTable({ limit = 10 }: RankingTableProps) {
         <table className="w-full min-w-[520px] table-fixed text-left text-sm">
           <thead>
             <tr className="text-muted-foreground border-b border-white/10 text-xs tracking-wider uppercase">
-              <th className="w-20 pr-2 pb-3">Rank</th>
-              <th className="pb-3">Player</th>
-              <th className="w-24 pr-2 pb-3 text-right">Level</th>
-              <th className="w-32 pb-3 text-right">Highest Floor</th>
+              <th className="w-20 pr-2 pb-3">{t("ranking.table.rank")}</th>
+              <th className="pb-3">{t("ranking.table.player")}</th>
+              <th className="w-24 pr-2 pb-3 text-right">
+                {t("ranking.table.level")}
+              </th>
+              <th className="w-32 pb-3 text-right">
+                {t("ranking.table.highestFloor")}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -69,13 +79,17 @@ export function RankingTable({ limit = 10 }: RankingTableProps) {
 
       <div className="flex items-center justify-center gap-3">
         {isFetchingNextPage ? (
-          <span className="pixel-text-muted text-sm">불러오는 중...</span>
+          <span className="pixel-text-muted text-sm">
+            {t("ranking.state.loadingMore")}
+          </span>
         ) : hasNextPage ? (
           <PixelButton onClick={() => fetchNextPage()} disabled={isRefreshing}>
-            더 보기
+            {t("ranking.state.loadMore")}
           </PixelButton>
         ) : (
-          <span className="pixel-text-muted text-sm">모두 불러왔습니다.</span>
+          <span className="pixel-text-muted text-sm">
+            {t("ranking.state.allLoaded")}
+          </span>
         )}
       </div>
     </PixelPanel>
@@ -83,6 +97,7 @@ export function RankingTable({ limit = 10 }: RankingTableProps) {
 }
 
 function RankingRow({ entry }: { entry: RankingEntry }) {
+  const { t } = useTranslation();
   const displayName = entry.displayName?.trim() ? entry.displayName : "-";
   const avatarUrl = entry.avatarUrl?.trim() ? entry.avatarUrl : null;
 
@@ -95,12 +110,12 @@ function RankingRow({ entry }: { entry: RankingEntry }) {
             {avatarUrl ? (
               <img
                 src={avatarUrl}
-                alt=""
+                alt={t("ranking.avatarAlt")}
                 className="h-full w-full object-cover"
                 loading="lazy"
               />
             ) : (
-              <span className="text-muted-foreground text-xs">-</span>
+              <span className="text-muted-foreground text-xs">—</span>
             )}
           </div>
           <span className="text-foreground min-w-0 truncate font-medium">

--- a/src/widgets/ranking-table/ui/ranking-table.tsx
+++ b/src/widgets/ranking-table/ui/ranking-table.tsx
@@ -1,0 +1,115 @@
+import { PixelButton } from "@/shared/ui/pixel-button";
+import {
+  PixelEmptyState,
+  PixelErrorState,
+  PixelSkeletonState,
+} from "@/shared/ui/pixel-state";
+import { PixelPanel } from "@/shared/ui/pixel-panel";
+import { useRankingList } from "@/widgets/ranking-table/model/use-ranking-list";
+import type { RankingEntry } from "@/entities/ranking/model/types";
+
+interface RankingTableProps {
+  limit?: number;
+}
+
+export function RankingTable({ limit = 10 }: RankingTableProps) {
+  const {
+    rankings,
+    status,
+    error,
+    isFetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = useRankingList({ limit });
+
+  if (status === "pending") {
+    return <PixelSkeletonState count={2} />;
+  }
+
+  if (status === "error") {
+    const message = error instanceof Error ? error.message : undefined;
+
+    return (
+      <PixelErrorState
+        message="랭킹 정보를 불러오지 못했습니다."
+        actions={<PixelButton onClick={() => refetch()}>다시 시도</PixelButton>}
+      >
+        {message ? <p className="pixel-text-muted text-xs">{message}</p> : null}
+      </PixelErrorState>
+    );
+  }
+
+  if (rankings.length === 0) {
+    return <PixelEmptyState message="표시할 랭킹이 없습니다." />;
+  }
+
+  const isRefreshing = isFetching || isFetchingNextPage;
+
+  return (
+    <PixelPanel className="p-4" contentClassName="space-y-4">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[520px] table-fixed text-left text-sm">
+          <thead>
+            <tr className="text-muted-foreground border-b border-white/10 text-xs tracking-wider uppercase">
+              <th className="w-20 pr-2 pb-3">Rank</th>
+              <th className="pb-3">Player</th>
+              <th className="w-24 pr-2 pb-3 text-right">Level</th>
+              <th className="w-32 pb-3 text-right">Highest Floor</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rankings.map((entry) => (
+              <RankingRow key={entry.rank} entry={entry} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-center gap-3">
+        {isFetchingNextPage ? (
+          <span className="pixel-text-muted text-sm">불러오는 중...</span>
+        ) : hasNextPage ? (
+          <PixelButton onClick={() => fetchNextPage()} disabled={isRefreshing}>
+            더 보기
+          </PixelButton>
+        ) : (
+          <span className="pixel-text-muted text-sm">모두 불러왔습니다.</span>
+        )}
+      </div>
+    </PixelPanel>
+  );
+}
+
+function RankingRow({ entry }: { entry: RankingEntry }) {
+  const displayName = entry.displayName?.trim() ? entry.displayName : "-";
+  const avatarUrl = entry.avatarUrl?.trim() ? entry.avatarUrl : null;
+
+  return (
+    <tr className="border-b border-white/10 last:border-0">
+      <td className="text-foreground py-3 pr-2 font-semibold">{entry.rank}</td>
+      <td className="py-3">
+        <div className="flex items-center gap-3">
+          <div className="pixel-avatar h-10 w-10 p-0">
+            {avatarUrl ? (
+              <img
+                src={avatarUrl}
+                alt=""
+                className="h-full w-full object-cover"
+                loading="lazy"
+              />
+            ) : (
+              <span className="text-muted-foreground text-xs">-</span>
+            )}
+          </div>
+          <span className="text-foreground min-w-0 truncate font-medium">
+            {displayName}
+          </span>
+        </div>
+      </td>
+      <td className="text-foreground py-3 pr-2 text-right">{entry.level}</td>
+      <td className="text-foreground py-3 text-right">{entry.maxFloor}</td>
+    </tr>
+  );
+}

--- a/src/widgets/ranking-table/ui/ranking-table.tsx
+++ b/src/widgets/ranking-table/ui/ranking-table.tsx
@@ -13,6 +13,8 @@ interface RankingTableProps {
   limit?: number;
 }
 
+const PANEL_MIN_HEIGHT_CLASS = "min-h-screen";
+
 export function RankingTable({ limit = 10 }: RankingTableProps) {
   const { t } = useTranslation();
   const {
@@ -27,7 +29,7 @@ export function RankingTable({ limit = 10 }: RankingTableProps) {
   } = useRankingList({ limit });
 
   if (status === "pending") {
-    return <PixelSkeletonState count={2} />;
+    return <PixelSkeletonState className={PANEL_MIN_HEIGHT_CLASS} count={2} />;
   }
 
   if (status === "error") {
@@ -35,6 +37,7 @@ export function RankingTable({ limit = 10 }: RankingTableProps) {
 
     return (
       <PixelErrorState
+        className={PANEL_MIN_HEIGHT_CLASS}
         message={t("ranking.state.error")}
         actions={
           <PixelButton onClick={() => refetch()}>
@@ -48,14 +51,22 @@ export function RankingTable({ limit = 10 }: RankingTableProps) {
   }
 
   if (rankings.length === 0) {
-    return <PixelEmptyState message={t("ranking.state.empty")} />;
+    return (
+      <PixelEmptyState
+        className={PANEL_MIN_HEIGHT_CLASS}
+        message={t("ranking.state.empty")}
+      />
+    );
   }
 
   const isRefreshing = isFetching || isFetchingNextPage;
 
   return (
-    <PixelPanel className="p-4" contentClassName="space-y-4">
-      <div className="overflow-x-auto">
+    <PixelPanel
+      className={`p-4 ${PANEL_MIN_HEIGHT_CLASS}`}
+      contentClassName="flex min-h-full flex-col gap-4"
+    >
+      <div className="flex-1 overflow-x-auto">
         <table className="w-full min-w-[520px] table-fixed text-left text-sm">
           <thead>
             <tr className="text-muted-foreground border-b border-white/10 text-xs tracking-wider uppercase">

--- a/src/widgets/ranking-table/ui/ranking-table.tsx
+++ b/src/widgets/ranking-table/ui/ranking-table.tsx
@@ -5,28 +5,25 @@ import {
   PixelSkeletonState,
 } from "@/shared/ui/pixel-state";
 import { PixelPanel } from "@/shared/ui/pixel-panel";
-import { useRankingList } from "@/widgets/ranking-table/model/use-ranking-list";
 import type { RankingEntry } from "@/entities/ranking/model/types";
 import { useTranslation } from "react-i18next";
+import type { RankingListState } from "@/features/ranking-list/model/use-ranking-list";
 
-interface RankingTableProps {
-  limit?: number;
-}
+type RankingTableProps = RankingListState;
 
 const PANEL_MIN_HEIGHT_CLASS = "min-h-screen";
 
-export function RankingTable({ limit = 10 }: RankingTableProps) {
+export function RankingTable({
+  rankings,
+  status,
+  error,
+  isFetching,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  refetch,
+}: RankingTableProps) {
   const { t } = useTranslation();
-  const {
-    rankings,
-    status,
-    error,
-    isFetching,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    refetch,
-  } = useRankingList({ limit });
 
   if (status === "pending") {
     return <PixelSkeletonState className={PANEL_MIN_HEIGHT_CLASS} count={2} />;

--- a/src/widgets/ranking-table/ui/ranking-table.tsx
+++ b/src/widgets/ranking-table/ui/ranking-table.tsx
@@ -11,7 +11,7 @@ import type { RankingListState } from "@/features/ranking-list/model/use-ranking
 
 type RankingTableProps = RankingListState;
 
-const PANEL_MIN_HEIGHT_CLASS = "min-h-screen";
+const PANEL_FLEX_CLASS = "flex-1";
 
 export function RankingTable({
   rankings,
@@ -26,7 +26,7 @@ export function RankingTable({
   const { t } = useTranslation();
 
   if (status === "pending") {
-    return <PixelSkeletonState className={PANEL_MIN_HEIGHT_CLASS} count={2} />;
+    return <PixelSkeletonState className={PANEL_FLEX_CLASS} count={2} />;
   }
 
   if (status === "error") {
@@ -34,7 +34,7 @@ export function RankingTable({
 
     return (
       <PixelErrorState
-        className={PANEL_MIN_HEIGHT_CLASS}
+        className={PANEL_FLEX_CLASS}
         message={t("ranking.state.error")}
         actions={
           <PixelButton onClick={() => refetch()}>
@@ -50,7 +50,7 @@ export function RankingTable({
   if (rankings.length === 0) {
     return (
       <PixelEmptyState
-        className={PANEL_MIN_HEIGHT_CLASS}
+        className={PANEL_FLEX_CLASS}
         message={t("ranking.state.empty")}
       />
     );
@@ -60,8 +60,8 @@ export function RankingTable({
 
   return (
     <PixelPanel
-      className={`p-4 ${PANEL_MIN_HEIGHT_CLASS}`}
-      contentClassName="flex min-h-full flex-col gap-4"
+      className={`p-4 ${PANEL_FLEX_CLASS}`}
+      contentClassName="flex min-h-0 flex-1 flex-col gap-4"
     >
       <div className="flex-1 overflow-x-auto">
         <table className="w-full min-w-[520px] table-fixed text-left text-sm">


### PR DESCRIPTION
## 개요

F035 랭킹 페이지 구현 완료

## 변경 사항

- 랭킹 API 스키마/쿼리 훅 및 MSW/테스트 추가
- /ranking 페이지 및 ranking-table UI/상태/더보기 구현
- 네비게이션 링크 및 i18n/플레이스홀더 정리, 레이아웃 안정화
- 랭킹 테이블 헤더 한국어 번역 보정

## 테스트

- [x] 유닛 테스트 통과
- [x] 통합 테스트 완료

### 실행 결과

- 명령어: `pnpm -C git-dungeon-fe test`, `pnpm -C git-dungeon-fe build`
- 결과: PASS (Test Files 34 / Tests 103, warning: i18n Missing translation key: translation:logs.deathCause.독), PASS (build, chunk size warning)

## 스크린샷 (UI 변경 시)

없음

## 관련 문서

- **Spec**: `docs/features/fe/F035-ranking-page/spec.md`
- **Tasks**: `docs/features/fe/F035-ranking-page/tasks.md`

Closes #71
