### PR TITLE
feat(#77): inventory-filters

### DIFF
--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -320,6 +320,29 @@
       "title": "Inventory",
       "equipped": "Equipped"
     },
+    "filters": {
+      "title": "Filter",
+      "labels": {
+        "equipped": "Equipped",
+        "sort": "Sort",
+        "slots": "Slots",
+        "rarity": "Rarity",
+        "acquired": "Acquired"
+      },
+      "options": {
+        "all": "All",
+        "equipped": "Equipped",
+        "unequipped": "Unequipped",
+        "sortDefault": "Default order",
+        "sortNewest": "Newest",
+        "sortOldest": "Oldest"
+      },
+      "date": {
+        "from": "From",
+        "to": "To",
+        "hint": "Leaving dates empty shows all items."
+      }
+    },
     "rarity": {
       "common": "Common",
       "uncommon": "Uncommon",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -320,6 +320,29 @@
       "title": "인벤토리",
       "equipped": "장착"
     },
+    "filters": {
+      "title": "필터",
+      "labels": {
+        "equipped": "장착 여부",
+        "sort": "정렬",
+        "slots": "슬롯",
+        "rarity": "희귀도",
+        "acquired": "획득일"
+      },
+      "options": {
+        "all": "전체",
+        "equipped": "장착",
+        "unequipped": "미장착",
+        "sortDefault": "기본 정렬",
+        "sortNewest": "획득일 최신",
+        "sortOldest": "획득일 오래된"
+      },
+      "date": {
+        "from": "시작",
+        "to": "끝",
+        "hint": "기간을 선택하지 않으면 전체 기간으로 표시됩니다."
+      }
+    },
     "rarity": {
       "common": "일반",
       "uncommon": "고급",

--- a/src/widgets/inventory/lib/inventory-filters.test.ts
+++ b/src/widgets/inventory/lib/inventory-filters.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterInventoryItems,
+  isWithinDateRange,
+  sortItemsByAcquiredAt,
+  sortItemsByDefault,
+  type InventoryFilterState,
+} from "@/widgets/inventory/lib/inventory-filters";
+import type { InventoryItem } from "@/entities/inventory/model/types";
+
+const baseItems: InventoryItem[] = [
+  {
+    id: "item-1",
+    code: "helmet-iron",
+    name: "Iron Helm",
+    slot: "helmet",
+    rarity: "common",
+    modifiers: [],
+    effect: null,
+    sprite: null,
+    createdAt: "2026-01-10T10:00:00.000Z",
+    isEquipped: true,
+    version: 1,
+  },
+  {
+    id: "item-2",
+    code: "weapon-sword",
+    name: "Sword",
+    slot: "weapon",
+    rarity: "rare",
+    modifiers: [],
+    effect: null,
+    sprite: null,
+    createdAt: "2026-01-12T10:00:00.000Z",
+    isEquipped: false,
+    version: 1,
+  },
+  {
+    id: "item-3",
+    code: "ring-gold",
+    name: "Gold Ring",
+    slot: "ring",
+    rarity: "epic",
+    modifiers: [],
+    effect: null,
+    sprite: null,
+    createdAt: "2026-01-11T10:00:00.000Z",
+    isEquipped: false,
+    version: 1,
+  },
+];
+
+const defaultFilterState: InventoryFilterState = {
+  equippedFilter: "ALL",
+  selectedSlots: [],
+  selectedRarities: [],
+  dateRange: {
+    start: "",
+    end: "",
+  },
+};
+
+describe("inventory-filters", () => {
+  describe("filterInventoryItems", () => {
+    it("filters by equipped state", () => {
+      const equippedOnly = filterInventoryItems(baseItems, {
+        ...defaultFilterState,
+        equippedFilter: "EQUIPPED",
+      });
+
+      expect(equippedOnly).toHaveLength(1);
+      expect(equippedOnly[0]?.id).toBe("item-1");
+    });
+
+    it("filters by slots", () => {
+      const filtered = filterInventoryItems(baseItems, {
+        ...defaultFilterState,
+        selectedSlots: ["weapon"],
+      });
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.id).toBe("item-2");
+    });
+
+    it("filters by rarities", () => {
+      const filtered = filterInventoryItems(baseItems, {
+        ...defaultFilterState,
+        selectedRarities: ["epic"],
+      });
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.id).toBe("item-3");
+    });
+
+    it("filters by date range", () => {
+      const filtered = filterInventoryItems(baseItems, {
+        ...defaultFilterState,
+        dateRange: {
+          start: "2026-01-11",
+          end: "2026-01-12",
+        },
+      });
+
+      expect(filtered.map((item) => item.id)).toEqual(["item-2", "item-3"]);
+    });
+  });
+
+  describe("sortItemsByDefault", () => {
+    it("sorts equipped first, then slot order, then acquired desc", () => {
+      const sorted = sortItemsByDefault(baseItems);
+      expect(sorted.map((item) => item.id)).toEqual([
+        "item-1",
+        "item-2",
+        "item-3",
+      ]);
+    });
+  });
+
+  describe("sortItemsByAcquiredAt", () => {
+    it("sorts by acquired asc", () => {
+      const sorted = sortItemsByAcquiredAt(baseItems, "ACQUIRED_ASC");
+      expect(sorted.map((item) => item.id)).toEqual([
+        "item-1",
+        "item-3",
+        "item-2",
+      ]);
+    });
+
+    it("sorts by acquired desc", () => {
+      const sorted = sortItemsByAcquiredAt(baseItems, "ACQUIRED_DESC");
+      expect(sorted.map((item) => item.id)).toEqual([
+        "item-2",
+        "item-3",
+        "item-1",
+      ]);
+    });
+  });
+
+  describe("isWithinDateRange", () => {
+    it("returns true when range is empty", () => {
+      expect(
+        isWithinDateRange("2026-01-10T10:00:00.000Z", {
+          start: "",
+          end: "",
+        })
+      ).toBe(true);
+    });
+
+    it("returns false for invalid date", () => {
+      expect(
+        isWithinDateRange("invalid-date", {
+          start: "2026-01-10",
+          end: "2026-01-11",
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/src/widgets/inventory/lib/inventory-filters.ts
+++ b/src/widgets/inventory/lib/inventory-filters.ts
@@ -1,0 +1,105 @@
+import type {
+  EquipmentRarity,
+  InventoryItem,
+  InventoryItemSlot,
+} from "@/entities/inventory/model/types";
+import type {
+  InventoryDateRange,
+  InventoryEquippedFilter,
+  InventorySortFilter,
+} from "@/widgets/inventory/ui/inventory-filters-panel";
+
+export interface InventoryFilterState {
+  equippedFilter: InventoryEquippedFilter;
+  selectedSlots: InventoryItemSlot[];
+  selectedRarities: EquipmentRarity[];
+  dateRange: InventoryDateRange;
+}
+
+const SLOT_ORDER: Record<InventoryItemSlot, number> = {
+  helmet: 0,
+  armor: 1,
+  weapon: 2,
+  ring: 3,
+  consumable: 4,
+};
+
+export function filterInventoryItems(
+  items: InventoryItem[],
+  {
+    equippedFilter,
+    selectedSlots,
+    selectedRarities,
+    dateRange,
+  }: InventoryFilterState
+) {
+  return items.filter((item) => {
+    if (equippedFilter === "EQUIPPED" && !item.isEquipped) {
+      return false;
+    }
+    if (equippedFilter === "UNEQUIPPED" && item.isEquipped) {
+      return false;
+    }
+    if (selectedSlots.length > 0 && !selectedSlots.includes(item.slot)) {
+      return false;
+    }
+    if (
+      selectedRarities.length > 0 &&
+      !selectedRarities.includes(item.rarity)
+    ) {
+      return false;
+    }
+    if (!isWithinDateRange(item.createdAt, dateRange)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function sortItemsByAcquiredAt(
+  items: InventoryItem[],
+  sortFilter: InventorySortFilter
+) {
+  const sorted = [...items].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+  return sortFilter === "ACQUIRED_DESC" ? sorted.reverse() : sorted;
+}
+
+export function sortItemsByDefault(items: InventoryItem[]) {
+  return [...items].sort((a, b) => {
+    if (a.isEquipped !== b.isEquipped) {
+      return a.isEquipped ? -1 : 1;
+    }
+
+    if (SLOT_ORDER[a.slot] !== SLOT_ORDER[b.slot]) {
+      return SLOT_ORDER[a.slot] - SLOT_ORDER[b.slot];
+    }
+
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+}
+
+export function isWithinDateRange(value: string, range: InventoryDateRange) {
+  const { start, end } = range;
+  if (!start && !end) {
+    return true;
+  }
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) {
+    return false;
+  }
+  if (start) {
+    const startTime = new Date(`${start}T00:00:00`).getTime();
+    if (timestamp < startTime) {
+      return false;
+    }
+  }
+  if (end) {
+    const endTime = new Date(`${end}T23:59:59.999`).getTime();
+    if (timestamp > endTime) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/widgets/inventory/ui/inventory-filters-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-filters-panel.tsx
@@ -1,4 +1,3 @@
-import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type {
   EquipmentRarity,
@@ -33,63 +32,72 @@ const RARITY_OPTIONS: EquipmentRarity[] = [
   "legendary",
 ];
 
-type EquippedFilter = "ALL" | "EQUIPPED" | "UNEQUIPPED";
-type SortFilter = "DEFAULT" | "ACQUIRED_DESC" | "ACQUIRED_ASC";
+export type InventoryEquippedFilter = "ALL" | "EQUIPPED" | "UNEQUIPPED";
+export type InventorySortFilter = "DEFAULT" | "ACQUIRED_DESC" | "ACQUIRED_ASC";
 
-interface DateRangeState {
+export interface InventoryDateRange {
   start: string;
   end: string;
 }
 
-export function InventoryFiltersPanel() {
-  const { t, i18n } = useTranslation();
-  const labels = useMemo(() => {
-    const isKo = i18n.language?.startsWith("ko");
-    return {
-      equippedLabel: isKo ? "장착 여부" : "Equipped",
-      sortLabel: isKo ? "정렬" : "Sort",
-      slotsLabel: isKo ? "슬롯" : "Slots",
-      rarityLabel: isKo ? "희귀도" : "Rarity",
-      dateLabel: isKo ? "획득일" : "Acquired",
-      all: isKo ? "전체" : "All",
-      equipped: isKo ? "장착" : "Equipped",
-      unequipped: isKo ? "미장착" : "Unequipped",
-      sortDefault: isKo ? "기본 정렬" : "Default order",
-      sortNewest: isKo ? "획득일 최신" : "Newest",
-      sortOldest: isKo ? "획득일 오래된" : "Oldest",
-      from: isKo ? "시작" : "From",
-      to: isKo ? "끝" : "To",
-      hint: isKo
-        ? "기간을 선택하지 않으면 전체 기간으로 표시됩니다."
-        : "Leaving dates empty shows all items.",
-    };
-  }, [i18n.language]);
+interface InventoryFiltersPanelProps {
+  equippedFilter: InventoryEquippedFilter;
+  sortFilter: InventorySortFilter;
+  selectedSlots: InventoryItemSlot[];
+  selectedRarities: EquipmentRarity[];
+  dateRange: InventoryDateRange;
+  onEquippedChange: (value: InventoryEquippedFilter) => void;
+  onSortChange: (value: InventorySortFilter) => void;
+  onSlotsChange: (value: InventoryItemSlot[]) => void;
+  onRaritiesChange: (value: EquipmentRarity[]) => void;
+  onDateRangeChange: (value: InventoryDateRange) => void;
+}
 
-  const [equippedFilter, setEquippedFilter] = useState<EquippedFilter>("ALL");
-  const [sortFilter, setSortFilter] = useState<SortFilter>("DEFAULT");
-  const [selectedSlots, setSelectedSlots] = useState<InventoryItemSlot[]>([]);
-  const [selectedRarities, setSelectedRarities] = useState<EquipmentRarity[]>(
-    []
-  );
-  const [dateRange, setDateRange] = useState<DateRangeState>({
-    start: "",
-    end: "",
-  });
+export function InventoryFiltersPanel({
+  equippedFilter,
+  sortFilter,
+  selectedSlots,
+  selectedRarities,
+  dateRange,
+  onEquippedChange,
+  onSortChange,
+  onSlotsChange,
+  onRaritiesChange,
+  onDateRangeChange,
+}: InventoryFiltersPanelProps) {
+  const { t, i18n } = useTranslation();
+  const isKo = i18n.language?.startsWith("ko");
+  const labels = {
+    equippedLabel: isKo ? "장착 여부" : "Equipped",
+    sortLabel: isKo ? "정렬" : "Sort",
+    slotsLabel: isKo ? "슬롯" : "Slots",
+    rarityLabel: isKo ? "희귀도" : "Rarity",
+    dateLabel: isKo ? "획득일" : "Acquired",
+    all: isKo ? "전체" : "All",
+    equipped: isKo ? "장착" : "Equipped",
+    unequipped: isKo ? "미장착" : "Unequipped",
+    sortDefault: isKo ? "기본 정렬" : "Default order",
+    sortNewest: isKo ? "획득일 최신" : "Newest",
+    sortOldest: isKo ? "획득일 오래된" : "Oldest",
+    from: isKo ? "시작" : "From",
+    to: isKo ? "끝" : "To",
+    hint: isKo
+      ? "기간을 선택하지 않으면 전체 기간으로 표시됩니다."
+      : "Leaving dates empty shows all items.",
+  };
 
   const toggleSlot = (slot: InventoryItemSlot) => {
-    setSelectedSlots((prev) =>
-      prev.includes(slot)
-        ? prev.filter((value) => value !== slot)
-        : [...prev, slot]
-    );
+    const next = selectedSlots.includes(slot)
+      ? selectedSlots.filter((value) => value !== slot)
+      : [...selectedSlots, slot];
+    onSlotsChange(next);
   };
 
   const toggleRarity = (rarity: EquipmentRarity) => {
-    setSelectedRarities((prev) =>
-      prev.includes(rarity)
-        ? prev.filter((value) => value !== rarity)
-        : [...prev, rarity]
-    );
+    const next = selectedRarities.includes(rarity)
+      ? selectedRarities.filter((value) => value !== rarity)
+      : [...selectedRarities, rarity];
+    onRaritiesChange(next);
   };
 
   return (
@@ -103,7 +111,9 @@ export function InventoryFiltersPanel() {
           <p className="pixel-text-muted text-xs">{labels.equippedLabel}</p>
           <Select
             value={equippedFilter}
-            onValueChange={(next) => setEquippedFilter(next as EquippedFilter)}
+            onValueChange={(next) =>
+              onEquippedChange(next as InventoryEquippedFilter)
+            }
           >
             <SelectTrigger className="pixel-select-trigger w-full">
               <SelectValue />
@@ -126,7 +136,7 @@ export function InventoryFiltersPanel() {
           <p className="pixel-text-muted text-xs">{labels.sortLabel}</p>
           <Select
             value={sortFilter}
-            onValueChange={(next) => setSortFilter(next as SortFilter)}
+            onValueChange={(next) => onSortChange(next as InventorySortFilter)}
           >
             <SelectTrigger className="pixel-select-trigger w-full">
               <SelectValue />
@@ -198,10 +208,10 @@ export function InventoryFiltersPanel() {
               value={dateRange.start}
               max={dateRange.end || undefined}
               onChange={(event) =>
-                setDateRange((prev) => ({
-                  ...prev,
+                onDateRangeChange({
+                  ...dateRange,
                   start: event.target.value,
-                }))
+                })
               }
               className="pixel-select-trigger w-full"
             />
@@ -213,10 +223,10 @@ export function InventoryFiltersPanel() {
               value={dateRange.end}
               min={dateRange.start || undefined}
               onChange={(event) =>
-                setDateRange((prev) => ({
-                  ...prev,
+                onDateRangeChange({
+                  ...dateRange,
                   end: event.target.value,
-                }))
+                })
               }
               className="pixel-select-trigger w-full"
             />

--- a/src/widgets/inventory/ui/inventory-filters-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-filters-panel.tsx
@@ -65,26 +65,7 @@ export function InventoryFiltersPanel({
   onRaritiesChange,
   onDateRangeChange,
 }: InventoryFiltersPanelProps) {
-  const { t, i18n } = useTranslation();
-  const isKo = i18n.language?.startsWith("ko");
-  const labels = {
-    equippedLabel: isKo ? "장착 여부" : "Equipped",
-    sortLabel: isKo ? "정렬" : "Sort",
-    slotsLabel: isKo ? "슬롯" : "Slots",
-    rarityLabel: isKo ? "희귀도" : "Rarity",
-    dateLabel: isKo ? "획득일" : "Acquired",
-    all: isKo ? "전체" : "All",
-    equipped: isKo ? "장착" : "Equipped",
-    unequipped: isKo ? "미장착" : "Unequipped",
-    sortDefault: isKo ? "기본 정렬" : "Default order",
-    sortNewest: isKo ? "획득일 최신" : "Newest",
-    sortOldest: isKo ? "획득일 오래된" : "Oldest",
-    from: isKo ? "시작" : "From",
-    to: isKo ? "끝" : "To",
-    hint: isKo
-      ? "기간을 선택하지 않으면 전체 기간으로 표시됩니다."
-      : "Leaving dates empty shows all items.",
-  };
+  const { t } = useTranslation();
 
   const toggleSlot = (slot: InventoryItemSlot) => {
     const next = selectedSlots.includes(slot)
@@ -102,13 +83,15 @@ export function InventoryFiltersPanel({
 
   return (
     <PixelPanel
-      title={t("logs.filters.title")}
+      title={t("inventory.filters.title")}
       className="p-4"
       contentClassName="space-y-4"
     >
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <div className="space-y-2">
-          <p className="pixel-text-muted text-xs">{labels.equippedLabel}</p>
+          <p className="pixel-text-muted text-xs">
+            {t("inventory.filters.labels.equipped")}
+          </p>
           <Select
             value={equippedFilter}
             onValueChange={(next) =>
@@ -120,20 +103,22 @@ export function InventoryFiltersPanel({
             </SelectTrigger>
             <SelectContent className="pixel-select-content">
               <SelectItem value="ALL" className="pixel-select-item">
-                {labels.all}
+                {t("inventory.filters.options.all")}
               </SelectItem>
               <SelectItem value="EQUIPPED" className="pixel-select-item">
-                {labels.equipped}
+                {t("inventory.filters.options.equipped")}
               </SelectItem>
               <SelectItem value="UNEQUIPPED" className="pixel-select-item">
-                {labels.unequipped}
+                {t("inventory.filters.options.unequipped")}
               </SelectItem>
             </SelectContent>
           </Select>
         </div>
 
         <div className="space-y-2">
-          <p className="pixel-text-muted text-xs">{labels.sortLabel}</p>
+          <p className="pixel-text-muted text-xs">
+            {t("inventory.filters.labels.sort")}
+          </p>
           <Select
             value={sortFilter}
             onValueChange={(next) => onSortChange(next as InventorySortFilter)}
@@ -143,13 +128,13 @@ export function InventoryFiltersPanel({
             </SelectTrigger>
             <SelectContent className="pixel-select-content">
               <SelectItem value="DEFAULT" className="pixel-select-item">
-                {labels.sortDefault}
+                {t("inventory.filters.options.sortDefault")}
               </SelectItem>
               <SelectItem value="ACQUIRED_DESC" className="pixel-select-item">
-                {labels.sortNewest}
+                {t("inventory.filters.options.sortNewest")}
               </SelectItem>
               <SelectItem value="ACQUIRED_ASC" className="pixel-select-item">
-                {labels.sortOldest}
+                {t("inventory.filters.options.sortOldest")}
               </SelectItem>
             </SelectContent>
           </Select>
@@ -158,7 +143,9 @@ export function InventoryFiltersPanel({
 
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <div className="space-y-2">
-          <p className="pixel-text-muted text-xs">{labels.slotsLabel}</p>
+          <p className="pixel-text-muted text-xs">
+            {t("inventory.filters.labels.slots")}
+          </p>
           <div className="flex flex-wrap gap-2">
             {SLOT_OPTIONS.map((slot) => {
               const isActive = selectedSlots.includes(slot);
@@ -178,7 +165,9 @@ export function InventoryFiltersPanel({
         </div>
 
         <div className="space-y-2">
-          <p className="pixel-text-muted text-xs">{labels.rarityLabel}</p>
+          <p className="pixel-text-muted text-xs">
+            {t("inventory.filters.labels.rarity")}
+          </p>
           <div className="flex flex-wrap gap-2">
             {RARITY_OPTIONS.map((rarity) => {
               const isActive = selectedRarities.includes(rarity);
@@ -199,10 +188,14 @@ export function InventoryFiltersPanel({
       </div>
 
       <div className="space-y-2">
-        <p className="pixel-text-muted text-xs">{labels.dateLabel}</p>
+        <p className="pixel-text-muted text-xs">
+          {t("inventory.filters.labels.acquired")}
+        </p>
         <div className="grid gap-3 md:grid-cols-2">
           <label className="space-y-1">
-            <span className="pixel-text-muted text-xs">{labels.from}</span>
+            <span className="pixel-text-muted text-xs">
+              {t("inventory.filters.date.from")}
+            </span>
             <input
               type="date"
               value={dateRange.start}
@@ -217,7 +210,9 @@ export function InventoryFiltersPanel({
             />
           </label>
           <label className="space-y-1">
-            <span className="pixel-text-muted text-xs">{labels.to}</span>
+            <span className="pixel-text-muted text-xs">
+              {t("inventory.filters.date.to")}
+            </span>
             <input
               type="date"
               value={dateRange.end}
@@ -232,7 +227,9 @@ export function InventoryFiltersPanel({
             />
           </label>
         </div>
-        <p className="pixel-text-muted text-xs">{labels.hint}</p>
+        <p className="pixel-text-muted text-xs">
+          {t("inventory.filters.date.hint")}
+        </p>
       </div>
     </PixelPanel>
   );

--- a/src/widgets/inventory/ui/inventory-filters-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-filters-panel.tsx
@@ -84,7 +84,6 @@ export function InventoryFiltersPanel({
   return (
     <PixelPanel
       title={t("inventory.filters.title")}
-      className="p-4"
       contentClassName="space-y-4"
     >
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">

--- a/src/widgets/inventory/ui/inventory-filters-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-filters-panel.tsx
@@ -1,0 +1,229 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type {
+  EquipmentRarity,
+  InventoryItemSlot,
+} from "@/entities/inventory/model/types";
+import { getInventorySlotLabel } from "@/entities/inventory/config/slot-labels";
+import { formatRarity } from "@/entities/dashboard/lib/formatters";
+import { PixelPanel } from "@/shared/ui/pixel-panel";
+import { PixelButton } from "@/shared/ui/pixel-button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
+import { cn } from "@/shared/lib/utils";
+
+const SLOT_OPTIONS: InventoryItemSlot[] = [
+  "helmet",
+  "armor",
+  "weapon",
+  "ring",
+  "consumable",
+];
+
+const RARITY_OPTIONS: EquipmentRarity[] = [
+  "common",
+  "uncommon",
+  "rare",
+  "epic",
+  "legendary",
+];
+
+type EquippedFilter = "ALL" | "EQUIPPED" | "UNEQUIPPED";
+type SortFilter = "DEFAULT" | "ACQUIRED_DESC" | "ACQUIRED_ASC";
+
+interface DateRangeState {
+  start: string;
+  end: string;
+}
+
+export function InventoryFiltersPanel() {
+  const { t, i18n } = useTranslation();
+  const labels = useMemo(() => {
+    const isKo = i18n.language?.startsWith("ko");
+    return {
+      equippedLabel: isKo ? "장착 여부" : "Equipped",
+      sortLabel: isKo ? "정렬" : "Sort",
+      slotsLabel: isKo ? "슬롯" : "Slots",
+      rarityLabel: isKo ? "희귀도" : "Rarity",
+      dateLabel: isKo ? "획득일" : "Acquired",
+      all: isKo ? "전체" : "All",
+      equipped: isKo ? "장착" : "Equipped",
+      unequipped: isKo ? "미장착" : "Unequipped",
+      sortDefault: isKo ? "기본 정렬" : "Default order",
+      sortNewest: isKo ? "획득일 최신" : "Newest",
+      sortOldest: isKo ? "획득일 오래된" : "Oldest",
+      from: isKo ? "시작" : "From",
+      to: isKo ? "끝" : "To",
+      hint: isKo
+        ? "기간을 선택하지 않으면 전체 기간으로 표시됩니다."
+        : "Leaving dates empty shows all items.",
+    };
+  }, [i18n.language]);
+
+  const [equippedFilter, setEquippedFilter] = useState<EquippedFilter>("ALL");
+  const [sortFilter, setSortFilter] = useState<SortFilter>("DEFAULT");
+  const [selectedSlots, setSelectedSlots] = useState<InventoryItemSlot[]>([]);
+  const [selectedRarities, setSelectedRarities] = useState<EquipmentRarity[]>(
+    []
+  );
+  const [dateRange, setDateRange] = useState<DateRangeState>({
+    start: "",
+    end: "",
+  });
+
+  const toggleSlot = (slot: InventoryItemSlot) => {
+    setSelectedSlots((prev) =>
+      prev.includes(slot)
+        ? prev.filter((value) => value !== slot)
+        : [...prev, slot]
+    );
+  };
+
+  const toggleRarity = (rarity: EquipmentRarity) => {
+    setSelectedRarities((prev) =>
+      prev.includes(rarity)
+        ? prev.filter((value) => value !== rarity)
+        : [...prev, rarity]
+    );
+  };
+
+  return (
+    <PixelPanel
+      title={t("logs.filters.title")}
+      className="p-4"
+      contentClassName="space-y-4"
+    >
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="space-y-2">
+          <p className="pixel-text-muted text-xs">{labels.equippedLabel}</p>
+          <Select
+            value={equippedFilter}
+            onValueChange={(next) => setEquippedFilter(next as EquippedFilter)}
+          >
+            <SelectTrigger className="pixel-select-trigger w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="pixel-select-content">
+              <SelectItem value="ALL" className="pixel-select-item">
+                {labels.all}
+              </SelectItem>
+              <SelectItem value="EQUIPPED" className="pixel-select-item">
+                {labels.equipped}
+              </SelectItem>
+              <SelectItem value="UNEQUIPPED" className="pixel-select-item">
+                {labels.unequipped}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <p className="pixel-text-muted text-xs">{labels.sortLabel}</p>
+          <Select
+            value={sortFilter}
+            onValueChange={(next) => setSortFilter(next as SortFilter)}
+          >
+            <SelectTrigger className="pixel-select-trigger w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="pixel-select-content">
+              <SelectItem value="DEFAULT" className="pixel-select-item">
+                {labels.sortDefault}
+              </SelectItem>
+              <SelectItem value="ACQUIRED_DESC" className="pixel-select-item">
+                {labels.sortNewest}
+              </SelectItem>
+              <SelectItem value="ACQUIRED_ASC" className="pixel-select-item">
+                {labels.sortOldest}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="space-y-2">
+          <p className="pixel-text-muted text-xs">{labels.slotsLabel}</p>
+          <div className="flex flex-wrap gap-2">
+            {SLOT_OPTIONS.map((slot) => {
+              const isActive = selectedSlots.includes(slot);
+              return (
+                <PixelButton
+                  key={slot}
+                  type="button"
+                  pixelSize="compact"
+                  className={cn(isActive && "pixel-button--active")}
+                  onClick={() => toggleSlot(slot)}
+                >
+                  {getInventorySlotLabel(slot)}
+                </PixelButton>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <p className="pixel-text-muted text-xs">{labels.rarityLabel}</p>
+          <div className="flex flex-wrap gap-2">
+            {RARITY_OPTIONS.map((rarity) => {
+              const isActive = selectedRarities.includes(rarity);
+              return (
+                <PixelButton
+                  key={rarity}
+                  type="button"
+                  pixelSize="compact"
+                  className={cn(isActive && "pixel-button--active")}
+                  onClick={() => toggleRarity(rarity)}
+                >
+                  {formatRarity(rarity)}
+                </PixelButton>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="pixel-text-muted text-xs">{labels.dateLabel}</p>
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="space-y-1">
+            <span className="pixel-text-muted text-xs">{labels.from}</span>
+            <input
+              type="date"
+              value={dateRange.start}
+              max={dateRange.end || undefined}
+              onChange={(event) =>
+                setDateRange((prev) => ({
+                  ...prev,
+                  start: event.target.value,
+                }))
+              }
+              className="pixel-select-trigger w-full"
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="pixel-text-muted text-xs">{labels.to}</span>
+            <input
+              type="date"
+              value={dateRange.end}
+              min={dateRange.start || undefined}
+              onChange={(event) =>
+                setDateRange((prev) => ({
+                  ...prev,
+                  end: event.target.value,
+                }))
+              }
+              className="pixel-select-trigger w-full"
+            />
+          </label>
+        </div>
+        <p className="pixel-text-muted text-xs">{labels.hint}</p>
+      </div>
+    </PixelPanel>
+  );
+}

--- a/src/widgets/inventory/ui/inventory-grid.tsx
+++ b/src/widgets/inventory/ui/inventory-grid.tsx
@@ -1,7 +1,4 @@
-import type {
-  InventoryItem,
-  InventoryItemSlot,
-} from "@/entities/inventory/model/types";
+import type { InventoryItem } from "@/entities/inventory/model/types";
 import { InventoryItemCard } from "@/entities/inventory/ui/inventory-item-card";
 import { PixelSlotButton } from "@/shared/ui/pixel-slot-button";
 import { PixelCheckIcon } from "@/shared/ui/pixel-check-icon";
@@ -14,48 +11,23 @@ interface InventoryGridProps {
   items: InventoryItem[];
   selectedItemId?: string | null;
   onSelect: (item: InventoryItem) => void;
-  disableDefaultSort?: boolean;
 }
-
-const SLOT_ORDER: Record<InventoryItemSlot, number> = {
-  helmet: 0,
-  armor: 1,
-  weapon: 2,
-  ring: 3,
-  consumable: 4,
-};
 
 export function InventoryGrid({
   items,
   selectedItemId,
   onSelect,
-  disableDefaultSort = false,
 }: InventoryGridProps) {
   const { t } = useTranslation();
   const resolveItemName = useCatalogItemNameResolver();
-  const sortedItems = disableDefaultSort
-    ? items
-    : [...items].sort((a, b) => {
-        if (a.isEquipped !== b.isEquipped) {
-          return a.isEquipped ? -1 : 1;
-        }
-
-        if (SLOT_ORDER[a.slot] !== SLOT_ORDER[b.slot]) {
-          return SLOT_ORDER[a.slot] - SLOT_ORDER[b.slot];
-        }
-
-        return (
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
-      });
 
   return (
     <PixelPanel title={t("inventory.grid.title")}>
-      {sortedItems.length === 0 ? (
+      {items.length === 0 ? (
         <PixelEmptyState message={t("inventory.empty")} />
       ) : (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {sortedItems.map((item) => (
+          {items.map((item) => (
             <InventoryGridCell
               key={item.id}
               item={item}

--- a/src/widgets/inventory/ui/inventory-grid.tsx
+++ b/src/widgets/inventory/ui/inventory-grid.tsx
@@ -14,6 +14,7 @@ interface InventoryGridProps {
   items: InventoryItem[];
   selectedItemId?: string | null;
   onSelect: (item: InventoryItem) => void;
+  disableDefaultSort?: boolean;
 }
 
 const SLOT_ORDER: Record<InventoryItemSlot, number> = {
@@ -28,20 +29,25 @@ export function InventoryGrid({
   items,
   selectedItemId,
   onSelect,
+  disableDefaultSort = false,
 }: InventoryGridProps) {
   const { t } = useTranslation();
   const resolveItemName = useCatalogItemNameResolver();
-  const sortedItems = [...items].sort((a, b) => {
-    if (a.isEquipped !== b.isEquipped) {
-      return a.isEquipped ? -1 : 1;
-    }
+  const sortedItems = disableDefaultSort
+    ? items
+    : [...items].sort((a, b) => {
+        if (a.isEquipped !== b.isEquipped) {
+          return a.isEquipped ? -1 : 1;
+        }
 
-    if (SLOT_ORDER[a.slot] !== SLOT_ORDER[b.slot]) {
-      return SLOT_ORDER[a.slot] - SLOT_ORDER[b.slot];
-    }
+        if (SLOT_ORDER[a.slot] !== SLOT_ORDER[b.slot]) {
+          return SLOT_ORDER[a.slot] - SLOT_ORDER[b.slot];
+        }
 
-    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-  });
+        return (
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+      });
 
   return (
     <PixelPanel title={t("inventory.grid.title")}>

--- a/src/widgets/inventory/ui/inventory-layout.tsx
+++ b/src/widgets/inventory/ui/inventory-layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type {
   InventoryEquippedMap,
   InventoryItem,
@@ -83,12 +83,16 @@ export function InventoryLayout({
     setSelectedSlot(null);
   };
 
-  const filteredItems = filterInventoryItems(items, {
-    equippedFilter,
-    selectedSlots,
-    selectedRarities,
-    dateRange,
-  });
+  const filteredItems = useMemo(
+    () =>
+      filterInventoryItems(items, {
+        equippedFilter,
+        selectedSlots,
+        selectedRarities,
+        dateRange,
+      }),
+    [items, equippedFilter, selectedSlots, selectedRarities, dateRange]
+  );
   const resolvedItems =
     sortFilter === "DEFAULT"
       ? sortItemsByDefault(filteredItems)

--- a/src/widgets/inventory/ui/inventory-layout.tsx
+++ b/src/widgets/inventory/ui/inventory-layout.tsx
@@ -1,13 +1,19 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type {
   InventoryEquippedMap,
   InventoryItem,
   InventoryItemSlot,
+  EquipmentRarity,
 } from "@/entities/inventory/model/types";
 import { InventorySlots } from "@/widgets/inventory/ui/inventory-slots";
 import { InventoryCharacterPanel } from "@/widgets/inventory/ui/inventory-character-panel";
 import { InventoryGrid } from "@/widgets/inventory/ui/inventory-grid";
-import { InventoryFiltersPanel } from "@/widgets/inventory/ui/inventory-filters-panel";
+import {
+  InventoryFiltersPanel,
+  type InventoryDateRange,
+  type InventoryEquippedFilter,
+  type InventorySortFilter,
+} from "@/widgets/inventory/ui/inventory-filters-panel";
 import { InventoryModal } from "@/widgets/inventory/ui/inventory-modal";
 import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
 
@@ -44,6 +50,17 @@ export function InventoryLayout({
   const [selectedSlot, setSelectedSlot] = useState<InventoryItemSlot | null>(
     null
   );
+  const [equippedFilter, setEquippedFilter] =
+    useState<InventoryEquippedFilter>("ALL");
+  const [sortFilter, setSortFilter] = useState<InventorySortFilter>("DEFAULT");
+  const [selectedSlots, setSelectedSlots] = useState<InventoryItemSlot[]>([]);
+  const [selectedRarities, setSelectedRarities] = useState<EquipmentRarity[]>(
+    []
+  );
+  const [dateRange, setDateRange] = useState<InventoryDateRange>({
+    start: "",
+    end: "",
+  });
 
   const selectedItem = useMemo(() => {
     if (!selectedItemId) {
@@ -65,6 +82,28 @@ export function InventoryLayout({
     setSelectedSlot(null);
   };
 
+  const filteredItems = filterInventoryItems(items, {
+    equippedFilter,
+    selectedSlots,
+    selectedRarities,
+    dateRange,
+  });
+  const shouldSkipDefaultSort = sortFilter !== "DEFAULT";
+  const resolvedItems = shouldSkipDefaultSort
+    ? sortItemsByAcquiredAt(filteredItems, sortFilter)
+    : filteredItems;
+
+  useEffect(() => {
+    if (!selectedItemId) {
+      return;
+    }
+    const exists = filteredItems.some((item) => item.id === selectedItemId);
+    if (!exists) {
+      setSelectedItemId(null);
+      setSelectedSlot(null);
+    }
+  }, [filteredItems, selectedItemId]);
+
   return (
     <div className="space-y-6">
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
@@ -80,12 +119,24 @@ export function InventoryLayout({
         />
       </div>
 
-      <InventoryFiltersPanel />
+      <InventoryFiltersPanel
+        equippedFilter={equippedFilter}
+        sortFilter={sortFilter}
+        selectedSlots={selectedSlots}
+        selectedRarities={selectedRarities}
+        dateRange={dateRange}
+        onEquippedChange={setEquippedFilter}
+        onSortChange={setSortFilter}
+        onSlotsChange={setSelectedSlots}
+        onRaritiesChange={setSelectedRarities}
+        onDateRangeChange={setDateRange}
+      />
 
       <InventoryGrid
-        items={items}
+        items={resolvedItems}
         selectedItemId={selectedItemId}
         onSelect={(item) => handleSelect(item, item.slot)}
+        disableDefaultSort={shouldSkipDefaultSort}
       />
 
       <InventoryModal
@@ -101,4 +152,77 @@ export function InventoryLayout({
       />
     </div>
   );
+}
+
+interface InventoryFilterState {
+  equippedFilter: InventoryEquippedFilter;
+  selectedSlots: InventoryItemSlot[];
+  selectedRarities: EquipmentRarity[];
+  dateRange: InventoryDateRange;
+}
+
+function filterInventoryItems(
+  items: InventoryItem[],
+  {
+    equippedFilter,
+    selectedSlots,
+    selectedRarities,
+    dateRange,
+  }: InventoryFilterState
+) {
+  return items.filter((item) => {
+    if (equippedFilter === "EQUIPPED" && !item.isEquipped) {
+      return false;
+    }
+    if (equippedFilter === "UNEQUIPPED" && item.isEquipped) {
+      return false;
+    }
+    if (selectedSlots.length > 0 && !selectedSlots.includes(item.slot)) {
+      return false;
+    }
+    if (
+      selectedRarities.length > 0 &&
+      !selectedRarities.includes(item.rarity)
+    ) {
+      return false;
+    }
+    if (!isWithinDateRange(item.createdAt, dateRange)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function sortItemsByAcquiredAt(
+  items: InventoryItem[],
+  sortFilter: InventorySortFilter
+) {
+  const sorted = [...items].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+  return sortFilter === "ACQUIRED_DESC" ? sorted.reverse() : sorted;
+}
+
+function isWithinDateRange(value: string, range: InventoryDateRange) {
+  const { start, end } = range;
+  if (!start && !end) {
+    return true;
+  }
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) {
+    return false;
+  }
+  if (start) {
+    const startTime = new Date(`${start}T00:00:00`).getTime();
+    if (timestamp < startTime) {
+      return false;
+    }
+  }
+  if (end) {
+    const endTime = new Date(`${end}T23:59:59.999`).getTime();
+    if (timestamp > endTime) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/widgets/inventory/ui/inventory-layout.tsx
+++ b/src/widgets/inventory/ui/inventory-layout.tsx
@@ -88,10 +88,10 @@ export function InventoryLayout({
     selectedRarities,
     dateRange,
   });
-  const shouldSkipDefaultSort = sortFilter !== "DEFAULT";
-  const resolvedItems = shouldSkipDefaultSort
-    ? sortItemsByAcquiredAt(filteredItems, sortFilter)
-    : filteredItems;
+  const resolvedItems =
+    sortFilter === "DEFAULT"
+      ? sortItemsByDefault(filteredItems)
+      : sortItemsByAcquiredAt(filteredItems, sortFilter);
 
   useEffect(() => {
     if (!selectedItemId) {
@@ -136,7 +136,6 @@ export function InventoryLayout({
         items={resolvedItems}
         selectedItemId={selectedItemId}
         onSelect={(item) => handleSelect(item, item.slot)}
-        disableDefaultSort={shouldSkipDefaultSort}
       />
 
       <InventoryModal
@@ -201,6 +200,28 @@ function sortItemsByAcquiredAt(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
   );
   return sortFilter === "ACQUIRED_DESC" ? sorted.reverse() : sorted;
+}
+
+const SLOT_ORDER: Record<InventoryItemSlot, number> = {
+  helmet: 0,
+  armor: 1,
+  weapon: 2,
+  ring: 3,
+  consumable: 4,
+};
+
+function sortItemsByDefault(items: InventoryItem[]) {
+  return [...items].sort((a, b) => {
+    if (a.isEquipped !== b.isEquipped) {
+      return a.isEquipped ? -1 : 1;
+    }
+
+    if (SLOT_ORDER[a.slot] !== SLOT_ORDER[b.slot]) {
+      return SLOT_ORDER[a.slot] - SLOT_ORDER[b.slot];
+    }
+
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
 }
 
 function isWithinDateRange(value: string, range: InventoryDateRange) {

--- a/src/widgets/inventory/ui/inventory-layout.tsx
+++ b/src/widgets/inventory/ui/inventory-layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import type {
   InventoryEquippedMap,
   InventoryItem,
@@ -15,6 +15,11 @@ import {
   type InventorySortFilter,
 } from "@/widgets/inventory/ui/inventory-filters-panel";
 import { InventoryModal } from "@/widgets/inventory/ui/inventory-modal";
+import {
+  filterInventoryItems,
+  sortItemsByAcquiredAt,
+  sortItemsByDefault,
+} from "@/widgets/inventory/lib/inventory-filters";
 import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
 
 interface InventoryLayoutProps {
@@ -62,13 +67,9 @@ export function InventoryLayout({
     end: "",
   });
 
-  const selectedItem = useMemo(() => {
-    if (!selectedItemId) {
-      return null;
-    }
-
-    return items.find((item) => item.id === selectedItemId) ?? null;
-  }, [items, selectedItemId]);
+  const selectedItem = selectedItemId
+    ? (items.find((item) => item.id === selectedItemId) ?? null)
+    : null;
 
   const handleSelect = (item: InventoryItem, slot: InventoryItemSlot) => {
     onClearError();
@@ -151,99 +152,4 @@ export function InventoryLayout({
       />
     </div>
   );
-}
-
-interface InventoryFilterState {
-  equippedFilter: InventoryEquippedFilter;
-  selectedSlots: InventoryItemSlot[];
-  selectedRarities: EquipmentRarity[];
-  dateRange: InventoryDateRange;
-}
-
-function filterInventoryItems(
-  items: InventoryItem[],
-  {
-    equippedFilter,
-    selectedSlots,
-    selectedRarities,
-    dateRange,
-  }: InventoryFilterState
-) {
-  return items.filter((item) => {
-    if (equippedFilter === "EQUIPPED" && !item.isEquipped) {
-      return false;
-    }
-    if (equippedFilter === "UNEQUIPPED" && item.isEquipped) {
-      return false;
-    }
-    if (selectedSlots.length > 0 && !selectedSlots.includes(item.slot)) {
-      return false;
-    }
-    if (
-      selectedRarities.length > 0 &&
-      !selectedRarities.includes(item.rarity)
-    ) {
-      return false;
-    }
-    if (!isWithinDateRange(item.createdAt, dateRange)) {
-      return false;
-    }
-    return true;
-  });
-}
-
-function sortItemsByAcquiredAt(
-  items: InventoryItem[],
-  sortFilter: InventorySortFilter
-) {
-  const sorted = [...items].sort(
-    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-  );
-  return sortFilter === "ACQUIRED_DESC" ? sorted.reverse() : sorted;
-}
-
-const SLOT_ORDER: Record<InventoryItemSlot, number> = {
-  helmet: 0,
-  armor: 1,
-  weapon: 2,
-  ring: 3,
-  consumable: 4,
-};
-
-function sortItemsByDefault(items: InventoryItem[]) {
-  return [...items].sort((a, b) => {
-    if (a.isEquipped !== b.isEquipped) {
-      return a.isEquipped ? -1 : 1;
-    }
-
-    if (SLOT_ORDER[a.slot] !== SLOT_ORDER[b.slot]) {
-      return SLOT_ORDER[a.slot] - SLOT_ORDER[b.slot];
-    }
-
-    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-  });
-}
-
-function isWithinDateRange(value: string, range: InventoryDateRange) {
-  const { start, end } = range;
-  if (!start && !end) {
-    return true;
-  }
-  const timestamp = new Date(value).getTime();
-  if (Number.isNaN(timestamp)) {
-    return false;
-  }
-  if (start) {
-    const startTime = new Date(`${start}T00:00:00`).getTime();
-    if (timestamp < startTime) {
-      return false;
-    }
-  }
-  if (end) {
-    const endTime = new Date(`${end}T23:59:59.999`).getTime();
-    if (timestamp > endTime) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/src/widgets/inventory/ui/inventory-layout.tsx
+++ b/src/widgets/inventory/ui/inventory-layout.tsx
@@ -7,6 +7,7 @@ import type {
 import { InventorySlots } from "@/widgets/inventory/ui/inventory-slots";
 import { InventoryCharacterPanel } from "@/widgets/inventory/ui/inventory-character-panel";
 import { InventoryGrid } from "@/widgets/inventory/ui/inventory-grid";
+import { InventoryFiltersPanel } from "@/widgets/inventory/ui/inventory-filters-panel";
 import { InventoryModal } from "@/widgets/inventory/ui/inventory-modal";
 import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
 
@@ -78,6 +79,8 @@ export function InventoryLayout({
           avatarUrl={avatarUrl}
         />
       </div>
+
+      <InventoryFiltersPanel />
 
       <InventoryGrid
         items={items}


### PR DESCRIPTION
## 개요
인벤토리 필터(장착 여부/슬롯/희귀도/획득일) UI와 클라이언트 필터/정렬 로직을 추가했습니다.

## 변경 사항
- 인벤토리 필터 패널 UI 추가 및 i18n 적용
- 필터/정렬 유틸 분리와 날짜 범위 처리
- 기본 정렬 로직 상위 이동 및 테스트 추가

## 테스트
> ⚠️ **실제 테스트 실행 후 체크하세요. 모든 항목이 체크되어야 합니다.**

- [x] 테스트 통과

### 실행 결과
- 명령어: `pnpm vitest run src/widgets/inventory/lib/inventory-filters.test.ts`
- 결과: PASS (9 tests)

## 스크린샷 (UI 변경 시)
- 없음

## 관련 문서
- **Spec**: `docs/features/fe/F040-inventory-filters/spec.md`
- **Tasks**: `docs/features/fe/F040-inventory-filters/tasks.md`

Closes #77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인벤토리에 필터 패널이 추가되어 장착 상태, 정렬, 슬롯, 레어도, 획득 날짜 범위로 아이템을 필터링·정렬할 수 있습니다.
  * 필터 조작에 따라 목록이 즉시 갱신되며, 필터로 선택된 항목이 목록에서 사라지면 선택이 자동 해제됩니다.

* **다국어**
  * 영어 및 한국어 번역이 추가되어 필터 UI가 현지화되었습니다.

* **테스트**
  * 필터링·정렬 동작에 대한 자동화 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->