### PR TITLE
feat(#85): pixel-ui-consistency (픽셀 UI 정합성 개선)

### DIFF
--- a/src/entities/dashboard/lib/progress.ts
+++ b/src/entities/dashboard/lib/progress.ts
@@ -5,14 +5,9 @@ import {
   MIN_FLOOR_PROGRESS,
   MIN_PERCENT,
 } from "@/entities/dashboard/config/constants";
+import { clampPercent } from "@/shared/lib/math";
 
-export function clampPercent(value: number): number {
-  if (!Number.isFinite(value)) {
-    return MIN_PERCENT;
-  }
-
-  return Math.min(Math.max(value, MIN_PERCENT), MAX_PERCENT);
-}
+export { clampPercent };
 
 export function calcPercent(current: number, max: number): number {
   if (!Number.isFinite(current) || !Number.isFinite(max) || max <= 0) {

--- a/src/features/level-up-banner/ui/level-up-banner.tsx
+++ b/src/features/level-up-banner/ui/level-up-banner.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { PixelPill } from "@/shared/ui/pixel-pill";
 import { PixelButton } from "@/shared/ui/pixel-button";
 import { cn } from "@/shared/lib/utils";
+import levelUpIcon from "@/assets/event/level-up.png";
 
 interface LevelUpBannerProps {
   points: number;
@@ -20,9 +21,16 @@ export function LevelUpBanner({ points, className }: LevelUpBannerProps) {
     <section className={cn("level-up-banner", className)}>
       <Link to="/level-up" className="level-up-banner-inner">
         <div className="level-up-banner-content">
-          <span className="level-up-banner-title font-pixel-title">
-            {t("levelUp.banner.title")}
-          </span>
+          <div className="level-up-banner-title-row">
+            <img
+              className="level-up-banner-icon"
+              src={levelUpIcon}
+              alt={t("levelUp.banner.iconAlt")}
+            />
+            <span className="level-up-banner-title font-pixel-title">
+              {t("levelUp.banner.title")}
+            </span>
+          </div>
           <span className="level-up-banner-message">
             {t("levelUp.banner.message", { points })}
           </span>

--- a/src/features/settings/ui/github-connection.tsx
+++ b/src/features/settings/ui/github-connection.tsx
@@ -1,9 +1,10 @@
-import { RefreshCw, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import {
   formatDateTime,
   formatRelativeTime,
 } from "@/shared/lib/datetime/formatters";
 import { PixelButton } from "@/shared/ui/pixel-button";
+import { PixelIcon } from "@/shared/ui/pixel-icon";
 import { normalizeError } from "@/shared/errors/normalize-error";
 import type { ProfileConnections } from "@/entities/profile/model/types";
 import { useGithubSyncStatus } from "@/entities/github/model/use-github-sync-status";
@@ -82,7 +83,7 @@ export function GithubConnection({ connections }: GithubConnectionProps) {
             {githubSync.isPending ? (
               <Loader2 className="size-4 animate-spin" aria-hidden />
             ) : (
-              <RefreshCw className="size-4" aria-hidden />
+              <PixelIcon name="refresh" size={16} className="shrink-0" />
             )}
             {t("settings.github.refresh")}
           </PixelButton>

--- a/src/features/settings/ui/profile-identity.tsx
+++ b/src/features/settings/ui/profile-identity.tsx
@@ -1,4 +1,5 @@
 import type { Profile } from "@/entities/profile/model/types";
+import { PixelAvatar } from "@/shared/ui/pixel-avatar";
 import { useTranslation } from "react-i18next";
 
 interface ProfileIdentityProps {
@@ -11,10 +12,12 @@ export function ProfileIdentity({ profile }: ProfileIdentityProps) {
 
   return (
     <div className="flex items-center gap-4">
-      <Avatar
-        media={profile.avatarUrl}
-        fallback={initials}
+      <PixelAvatar
+        src={profile.avatarUrl}
         alt={t("settings.profile.avatarAlt")}
+        fallback={<span className="text-base font-semibold">{initials}</span>}
+        className="size-16 p-0"
+        imageClassName="h-full w-full object-cover"
       />
       <div className="space-y-1">
         <p className="pixel-text-base text-lg font-semibold">
@@ -38,29 +41,4 @@ function resolveInitials(profile: Profile): string {
     .join("")
     .slice(0, 2)
     .toUpperCase();
-}
-
-function Avatar({
-  media,
-  fallback,
-  alt,
-}: {
-  media?: string;
-  fallback: string;
-  alt: string;
-}) {
-  return (
-    <div className="bg-muted pixel-text-base flex size-16 items-center justify-center overflow-hidden rounded-full border">
-      {media ? (
-        <img
-          src={media}
-          alt={alt}
-          className="size-full object-cover"
-          loading="lazy"
-        />
-      ) : (
-        <span className="text-base font-semibold">{fallback}</span>
-      )}
-    </div>
-  );
 }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -40,6 +40,7 @@
   "levelUp": {
     "banner": {
       "title": "LEVEL UP!",
+      "iconAlt": "Level up",
       "message": "{{points}} level-up points available.",
       "points": "{{points}} POINTS",
       "cta": "Choose stats"

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -40,6 +40,7 @@
   "levelUp": {
     "banner": {
       "title": "LEVEL UP!",
+      "iconAlt": "레벨업",
       "message": "레벨업 포인트 {{points}}개가 남아 있습니다.",
       "points": "{{points}} 포인트",
       "cta": "능력치 선택"

--- a/src/shared/lib/math.ts
+++ b/src/shared/lib/math.ts
@@ -1,0 +1,10 @@
+const MIN_PERCENT = 0;
+const MAX_PERCENT = 100;
+
+export function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) {
+    return MIN_PERCENT;
+  }
+
+  return Math.min(MAX_PERCENT, Math.max(MIN_PERCENT, value));
+}

--- a/src/shared/ui/pixel-avatar.stories.tsx
+++ b/src/shared/ui/pixel-avatar.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PixelAvatar } from "@/shared/ui/pixel-avatar";
+
+const meta: Meta<typeof PixelAvatar> = {
+  title: "shared/PixelAvatar",
+  component: PixelAvatar,
+  args: {
+    src: "/vite.svg",
+    alt: "Avatar",
+    className: "size-16 p-0",
+    imageClassName: "h-full w-full object-contain",
+  },
+  render: (args) => (
+    <div className="pixel-app p-4">
+      <PixelAvatar {...args} />
+    </div>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PixelAvatar>;
+
+export const Default: Story = {};
+
+export const FallbackInitials: Story = {
+  args: { src: null },
+  render: (args) => (
+    <div className="pixel-app p-4">
+      <PixelAvatar
+        {...args}
+        fallback={<span className="text-base font-semibold">GD</span>}
+      />
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="pixel-app flex flex-wrap items-center gap-6 p-6">
+      <PixelAvatar
+        src="/vite.svg"
+        alt="Small avatar"
+        className="size-10 p-0"
+        imageClassName="h-full w-full object-contain"
+      />
+      <PixelAvatar
+        src="/vite.svg"
+        alt="Medium avatar"
+        className="size-14 p-0"
+        imageClassName="h-full w-full object-contain"
+      />
+      <PixelAvatar
+        src="/vite.svg"
+        alt="Large avatar"
+        className="size-20 p-0"
+        imageClassName="h-full w-full object-contain"
+      />
+      <PixelAvatar
+        src={null}
+        alt="Fallback avatar"
+        className="size-16 p-0"
+        fallback={<span className="text-base font-semibold">GD</span>}
+      />
+    </div>
+  ),
+};

--- a/src/shared/ui/pixel-avatar.tsx
+++ b/src/shared/ui/pixel-avatar.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+import { cn } from "@/shared/lib/utils";
+
+interface PixelAvatarProps {
+  src?: string | null;
+  alt: string;
+  fallback?: ReactNode;
+  className?: string;
+  imageClassName?: string;
+  loading?: "eager" | "lazy";
+}
+
+export function PixelAvatar({
+  src,
+  alt,
+  fallback,
+  className,
+  imageClassName,
+  loading = "lazy",
+}: PixelAvatarProps) {
+  const resolvedSrc = src?.trim() ? src : null;
+
+  return (
+    <div
+      className={cn("pixel-avatar", className)}
+      {...(!resolvedSrc ? { role: "img", "aria-label": alt } : undefined)}
+    >
+      {resolvedSrc ? (
+        <img
+          src={resolvedSrc}
+          alt={alt}
+          className={cn("h-full w-full object-contain", imageClassName)}
+          loading={loading}
+        />
+      ) : (
+        <div
+          className={cn(
+            "pixel-text-base flex h-full w-full items-center justify-center",
+            imageClassName
+          )}
+          aria-hidden
+        >
+          {fallback ?? <span className="pixel-text-muted text-xs">—</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/shared/ui/pixel-avatar.tsx
+++ b/src/shared/ui/pixel-avatar.tsx
@@ -19,6 +19,9 @@ export function PixelAvatar({
   loading = "lazy",
 }: PixelAvatarProps) {
   const resolvedSrc = src?.trim() ? src : null;
+  const resolvedImageClassName = resolvedSrc
+    ? cn("object-contain", imageClassName ?? "h-full w-full")
+    : cn("flex items-center justify-center", imageClassName ?? "h-full w-full");
 
   return (
     <div
@@ -29,17 +32,11 @@ export function PixelAvatar({
         <img
           src={resolvedSrc}
           alt={alt}
-          className={cn("h-full w-full object-contain", imageClassName)}
+          className={resolvedImageClassName}
           loading={loading}
         />
       ) : (
-        <div
-          className={cn(
-            "pixel-text-base flex h-full w-full items-center justify-center",
-            imageClassName
-          )}
-          aria-hidden
-        >
+        <div className={resolvedImageClassName} aria-hidden>
           {fallback ?? <span className="pixel-text-muted text-xs">—</span>}
         </div>
       )}

--- a/src/shared/ui/pixel-progress.stories.tsx
+++ b/src/shared/ui/pixel-progress.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PixelProgress } from "@/shared/ui/pixel-progress";
+
+const meta: Meta<typeof PixelProgress> = {
+  title: "shared/PixelProgress",
+  component: PixelProgress,
+  args: {
+    percent: 45,
+    tone: "hp",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PixelProgress>;
+
+export const Default: Story = {};
+
+export const Tones: Story = {
+  render: () => (
+    <div className="pixel-app space-y-3 p-4">
+      <PixelProgress percent={72} tone="hp" ariaLabel="HP" />
+      <PixelProgress percent={44} tone="exp" ariaLabel="EXP" />
+      <PixelProgress percent={18} tone="progress" ariaLabel="Progress" />
+    </div>
+  ),
+};
+
+export const WithValue: Story = {
+  args: {
+    percent: 60,
+    tone: "exp",
+    size: "value",
+    valueLabel: "60%",
+    ariaLabel: "EXP",
+  },
+  render: (args) => (
+    <div className="pixel-app p-4">
+      <PixelProgress {...args} />
+    </div>
+  ),
+};

--- a/src/shared/ui/pixel-progress.tsx
+++ b/src/shared/ui/pixel-progress.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { clampPercent } from "@/shared/lib/math";
 import { cn } from "@/shared/lib/utils";
 
 type PixelProgressTone = "hp" | "exp" | "progress";
@@ -11,13 +12,6 @@ interface PixelProgressProps {
   className?: string;
   valueLabel?: ReactNode;
   ariaLabel?: string;
-}
-
-function clampPercent(value: number) {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-  return Math.min(100, Math.max(0, value));
 }
 
 export function PixelProgress({

--- a/src/shared/ui/pixel-progress.tsx
+++ b/src/shared/ui/pixel-progress.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { cn } from "@/shared/lib/utils";
+
+type PixelProgressTone = "hp" | "exp" | "progress";
+type PixelProgressSize = "default" | "value";
+
+interface PixelProgressProps {
+  percent: number;
+  tone?: PixelProgressTone;
+  size?: PixelProgressSize;
+  className?: string;
+  valueLabel?: ReactNode;
+  ariaLabel?: string;
+}
+
+function clampPercent(value: number) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, value));
+}
+
+export function PixelProgress({
+  percent,
+  tone = "hp",
+  size = "default",
+  className,
+  valueLabel,
+  ariaLabel,
+}: PixelProgressProps) {
+  const resolvedPercent = clampPercent(percent);
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={ariaLabel}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={resolvedPercent}
+      className={cn(
+        "pixel-bar",
+        size === "value" && "pixel-bar--value",
+        className
+      )}
+    >
+      <div
+        className={cn("pixel-bar-fill", `pixel-bar-fill--${tone}`)}
+        style={{ width: `${resolvedPercent}%` }}
+      />
+      {valueLabel ? (
+        <span className="pixel-bar-value">{valueLabel}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/shared/ui/stat-value-with-bonus.tsx
+++ b/src/shared/ui/stat-value-with-bonus.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { cn } from "@/shared/lib/utils";
+
+interface StatValueWithBonusProps {
+  bonus: number;
+  children: ReactNode;
+  format?: (value: number) => string;
+}
+
+function defaultFormat(value: number) {
+  return `${value}`;
+}
+
+export function StatValueWithBonus({
+  bonus,
+  children,
+  format = defaultFormat,
+}: StatValueWithBonusProps) {
+  if (!Number.isFinite(bonus) || bonus === 0) {
+    return <>{children}</>;
+  }
+
+  const sign = bonus > 0 ? "+" : "";
+  const toneClass =
+    bonus > 0
+      ? "text-emerald-600 dark:text-emerald-400"
+      : "text-rose-600 dark:text-rose-400";
+
+  return (
+    <>
+      {children}
+      <span className={cn("ml-1", toneClass)}>
+        ({sign}
+        {format(bonus)})
+      </span>
+    </>
+  );
+}

--- a/src/styles/pixel-theme.css
+++ b/src/styles/pixel-theme.css
@@ -601,6 +601,18 @@
     gap: 4px;
   }
 
+  .level-up-banner-title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .level-up-banner-icon {
+    width: 32px;
+    height: 32px;
+    image-rendering: pixelated;
+  }
+
   .level-up-banner-title {
     font-size: 1rem;
   }

--- a/src/styles/pixel-theme.css
+++ b/src/styles/pixel-theme.css
@@ -1741,13 +1741,25 @@
   .pixel-avatar {
     background: var(--pixel-surface-deep);
     border: 2px solid var(--pixel-border-strong);
-    border-radius: 12px;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+    border-radius: 0;
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+      0 2px 0 rgba(0, 0, 0, 0.35);
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 10px;
     overflow: hidden;
+    clip-path: polygon(
+      3px 0,
+      calc(100% - 3px) 0,
+      100% 3px,
+      100% calc(100% - 3px),
+      calc(100% - 3px) 100%,
+      3px 100%,
+      0 calc(100% - 3px),
+      0 3px
+    );
   }
 
   .pixel-select-trigger {

--- a/src/widgets/dashboard-skin/ui/dashboard-attributes-panel.tsx
+++ b/src/widgets/dashboard-skin/ui/dashboard-attributes-panel.tsx
@@ -9,6 +9,25 @@ interface DashboardAttributesPanelProps {
   ap: number;
 }
 
+function formatBonus(value: number) {
+  if (!value) {
+    return null;
+  }
+
+  const sign = value > 0 ? "+" : "";
+  const toneClass =
+    value > 0
+      ? "text-emerald-600 dark:text-emerald-400"
+      : "text-rose-600 dark:text-rose-400";
+
+  return (
+    <span className={toneClass}>
+      ({sign}
+      {formatNumber(value)})
+    </span>
+  );
+}
+
 export function DashboardAttributesPanel({
   stats,
   ap,
@@ -19,22 +38,54 @@ export function DashboardAttributesPanel({
     {
       key: "hp",
       label: t("dashboard.attributes.hp"),
-      value: `${formatNumber(stats.total.hp)} / ${formatNumber(stats.total.maxHp)}`,
+      value: (() => {
+        const bonus = formatBonus(stats.equipmentBonus.maxHp);
+        return (
+          <>
+            {formatNumber(stats.total.hp)} / {formatNumber(stats.total.maxHp)}
+            {bonus ? <span className="ml-1">{bonus}</span> : null}
+          </>
+        );
+      })(),
     },
     {
       key: "atk",
       label: t("dashboard.attributes.atk"),
-      value: formatNumber(stats.total.atk),
+      value: (() => {
+        const bonus = formatBonus(stats.equipmentBonus.atk);
+        return (
+          <>
+            {formatNumber(stats.total.atk)}
+            {bonus ? <span className="ml-1">{bonus}</span> : null}
+          </>
+        );
+      })(),
     },
     {
       key: "def",
       label: t("dashboard.attributes.def"),
-      value: formatNumber(stats.total.def),
+      value: (() => {
+        const bonus = formatBonus(stats.equipmentBonus.def);
+        return (
+          <>
+            {formatNumber(stats.total.def)}
+            {bonus ? <span className="ml-1">{bonus}</span> : null}
+          </>
+        );
+      })(),
     },
     {
       key: "luck",
       label: t("dashboard.attributes.luck"),
-      value: formatNumber(stats.total.luck),
+      value: (() => {
+        const bonus = formatBonus(stats.equipmentBonus.luck);
+        return (
+          <>
+            {formatNumber(stats.total.luck)}
+            {bonus ? <span className="ml-1">{bonus}</span> : null}
+          </>
+        );
+      })(),
     },
     {
       key: "ap",

--- a/src/widgets/dashboard-skin/ui/dashboard-attributes-panel.tsx
+++ b/src/widgets/dashboard-skin/ui/dashboard-attributes-panel.tsx
@@ -1,31 +1,13 @@
 import { formatNumber } from "@/entities/dashboard/lib/formatters";
 import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
 import { PixelPanel } from "@/shared/ui/pixel-panel";
+import { StatValueWithBonus } from "@/shared/ui/stat-value-with-bonus";
 import { DashboardStatRow } from "@/widgets/dashboard-skin/ui/dashboard-stat-row";
 import { useTranslation } from "react-i18next";
 
 interface DashboardAttributesPanelProps {
   stats: CharacterStatSummary;
   ap: number;
-}
-
-function formatBonus(value: number) {
-  if (!value) {
-    return null;
-  }
-
-  const sign = value > 0 ? "+" : "";
-  const toneClass =
-    value > 0
-      ? "text-emerald-600 dark:text-emerald-400"
-      : "text-rose-600 dark:text-rose-400";
-
-  return (
-    <span className={toneClass}>
-      ({sign}
-      {formatNumber(value)})
-    </span>
-  );
 }
 
 export function DashboardAttributesPanel({
@@ -38,54 +20,52 @@ export function DashboardAttributesPanel({
     {
       key: "hp",
       label: t("dashboard.attributes.hp"),
-      value: (() => {
-        const bonus = formatBonus(stats.equipmentBonus.maxHp);
-        return (
+      value: (
+        <StatValueWithBonus
+          bonus={stats.equipmentBonus.maxHp}
+          format={formatNumber}
+        >
           <>
             {formatNumber(stats.total.hp)} / {formatNumber(stats.total.maxHp)}
-            {bonus ? <span className="ml-1">{bonus}</span> : null}
           </>
-        );
-      })(),
+        </StatValueWithBonus>
+      ),
     },
     {
       key: "atk",
       label: t("dashboard.attributes.atk"),
-      value: (() => {
-        const bonus = formatBonus(stats.equipmentBonus.atk);
-        return (
-          <>
-            {formatNumber(stats.total.atk)}
-            {bonus ? <span className="ml-1">{bonus}</span> : null}
-          </>
-        );
-      })(),
+      value: (
+        <StatValueWithBonus
+          bonus={stats.equipmentBonus.atk}
+          format={formatNumber}
+        >
+          {formatNumber(stats.total.atk)}
+        </StatValueWithBonus>
+      ),
     },
     {
       key: "def",
       label: t("dashboard.attributes.def"),
-      value: (() => {
-        const bonus = formatBonus(stats.equipmentBonus.def);
-        return (
-          <>
-            {formatNumber(stats.total.def)}
-            {bonus ? <span className="ml-1">{bonus}</span> : null}
-          </>
-        );
-      })(),
+      value: (
+        <StatValueWithBonus
+          bonus={stats.equipmentBonus.def}
+          format={formatNumber}
+        >
+          {formatNumber(stats.total.def)}
+        </StatValueWithBonus>
+      ),
     },
     {
       key: "luck",
       label: t("dashboard.attributes.luck"),
-      value: (() => {
-        const bonus = formatBonus(stats.equipmentBonus.luck);
-        return (
-          <>
-            {formatNumber(stats.total.luck)}
-            {bonus ? <span className="ml-1">{bonus}</span> : null}
-          </>
-        );
-      })(),
+      value: (
+        <StatValueWithBonus
+          bonus={stats.equipmentBonus.luck}
+          format={formatNumber}
+        >
+          {formatNumber(stats.total.luck)}
+        </StatValueWithBonus>
+      ),
     },
     {
       key: "ap",

--- a/src/widgets/dashboard-skin/ui/dashboard-stat-bar.tsx
+++ b/src/widgets/dashboard-skin/ui/dashboard-stat-bar.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/shared/lib/utils";
+import { PixelProgress } from "@/shared/ui/pixel-progress";
 
 interface DashboardStatBarProps {
   label: string;
@@ -30,13 +31,14 @@ export function DashboardStatBar({
     return (
       <div className={cn("pixel-stat-bar", className)}>
         <span className="pixel-stat-label pixel-stat-label--bar">{label}</span>
-        <div className="pixel-bar pixel-bar--value flex-1">
-          <div
-            className={cn("pixel-bar-fill", `pixel-bar-fill--${tone}`)}
-            style={{ width: `${percent}%` }}
-          />
-          <span className="pixel-bar-value">{value}</span>
-        </div>
+        <PixelProgress
+          className="flex-1"
+          percent={percent}
+          tone={tone}
+          size="value"
+          valueLabel={value}
+          ariaLabel={label}
+        />
       </div>
     );
   }
@@ -47,12 +49,7 @@ export function DashboardStatBar({
         <span className="pixel-stat-label">{label}</span>
         <span className="pixel-stat-value">{value}</span>
       </div>
-      <div className="pixel-bar">
-        <div
-          className={cn("pixel-bar-fill", `pixel-bar-fill--${tone}`)}
-          style={{ width: `${percent}%` }}
-        />
-      </div>
+      <PixelProgress percent={percent} tone={tone} ariaLabel={label} />
     </div>
   );
 }

--- a/src/widgets/dashboard-skin/ui/dashboard-summary-panel.tsx
+++ b/src/widgets/dashboard-skin/ui/dashboard-summary-panel.tsx
@@ -5,6 +5,7 @@ import {
 import type { InventoryItem } from "@/entities/inventory/model/types";
 import { formatNumber } from "@/entities/dashboard/lib/formatters";
 import { calcRoundedPercent } from "@/entities/dashboard/lib/progress";
+import { PixelAvatar } from "@/shared/ui/pixel-avatar";
 import { PixelPanel } from "@/shared/ui/pixel-panel";
 import { DashboardStatBar } from "@/widgets/dashboard-skin/ui/dashboard-stat-bar";
 import { DashboardStatRow } from "@/widgets/dashboard-skin/ui/dashboard-stat-row";
@@ -49,13 +50,12 @@ export function DashboardSummaryPanel({
       contentClassName="gap-4"
     >
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
-        <div className="pixel-avatar w-fit">
-          <img
-            src={avatarSrc}
-            alt={t("dashboard.summaryRows.avatar")}
-            className="h-16 w-16 object-contain"
-          />
-        </div>
+        <PixelAvatar
+          src={avatarSrc}
+          alt={t("dashboard.summaryRows.avatar")}
+          className="w-fit"
+          imageClassName="h-16 w-16 object-contain"
+        />
         <div className="flex-1 space-y-3">
           <DashboardStatRow
             label={t("dashboard.summaryRows.level")}

--- a/src/widgets/inventory/ui/inventory-character-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-character-panel.tsx
@@ -2,6 +2,7 @@ import { MISSING_SPRITE } from "@/entities/catalog/config/local-sprites";
 import { formatNumber } from "@/entities/dashboard/lib/formatters";
 import { PixelAvatar } from "@/shared/ui/pixel-avatar";
 import { PixelPanel } from "@/shared/ui/pixel-panel";
+import { StatValueWithBonus } from "@/shared/ui/stat-value-with-bonus";
 import { DashboardStatRow } from "@/widgets/dashboard-skin/ui/dashboard-stat-row";
 import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
 import { useTranslation } from "react-i18next";
@@ -19,23 +20,6 @@ export function InventoryCharacterPanel({
 }: InventoryCharacterPanelProps) {
   const { t } = useTranslation();
 
-  const formatBonus = (value: number) => {
-    if (!value) {
-      return null;
-    }
-    const sign = value > 0 ? "+" : "";
-    const toneClass =
-      value > 0
-        ? "text-emerald-600 dark:text-emerald-400"
-        : "text-rose-600 dark:text-rose-400";
-    return (
-      <span className={toneClass}>
-        ({sign}
-        {formatNumber(value)})
-      </span>
-    );
-  };
-
   const rows = [
     {
       key: "level",
@@ -45,54 +29,52 @@ export function InventoryCharacterPanel({
     {
       key: "hp",
       label: t("dashboard.attributes.hp"),
-      value: (() => {
-        const bonus = formatBonus(stats.equipmentBonus.maxHp);
-        return (
+      value: (
+        <StatValueWithBonus
+          bonus={stats.equipmentBonus.maxHp}
+          format={formatNumber}
+        >
           <>
             {formatNumber(stats.total.hp)} / {formatNumber(stats.total.maxHp)}
-            {bonus ? <span className="ml-1">{bonus}</span> : null}
           </>
-        );
-      })(),
+        </StatValueWithBonus>
+      ),
     },
     {
       key: "atk",
       label: t("dashboard.attributes.atk"),
-      value: (() => {
-        const bonus = formatBonus(stats.equipmentBonus.atk);
-        return (
-          <>
-            {formatNumber(stats.total.atk)}
-            {bonus ? <span className="ml-1">{bonus}</span> : null}
-          </>
-        );
-      })(),
+      value: (
+        <StatValueWithBonus
+          bonus={stats.equipmentBonus.atk}
+          format={formatNumber}
+        >
+          {formatNumber(stats.total.atk)}
+        </StatValueWithBonus>
+      ),
     },
     {
       key: "def",
       label: t("dashboard.attributes.def"),
-      value: (() => {
-        const bonus = formatBonus(stats.equipmentBonus.def);
-        return (
-          <>
-            {formatNumber(stats.total.def)}
-            {bonus ? <span className="ml-1">{bonus}</span> : null}
-          </>
-        );
-      })(),
+      value: (
+        <StatValueWithBonus
+          bonus={stats.equipmentBonus.def}
+          format={formatNumber}
+        >
+          {formatNumber(stats.total.def)}
+        </StatValueWithBonus>
+      ),
     },
     {
       key: "luck",
       label: t("dashboard.attributes.luck"),
-      value: (() => {
-        const bonus = formatBonus(stats.equipmentBonus.luck);
-        return (
-          <>
-            {formatNumber(stats.total.luck)}
-            {bonus ? <span className="ml-1">{bonus}</span> : null}
-          </>
-        );
-      })(),
+      value: (
+        <StatValueWithBonus
+          bonus={stats.equipmentBonus.luck}
+          format={formatNumber}
+        >
+          {formatNumber(stats.total.luck)}
+        </StatValueWithBonus>
+      ),
     },
   ];
 

--- a/src/widgets/inventory/ui/inventory-character-panel.tsx
+++ b/src/widgets/inventory/ui/inventory-character-panel.tsx
@@ -1,5 +1,6 @@
 import { MISSING_SPRITE } from "@/entities/catalog/config/local-sprites";
 import { formatNumber } from "@/entities/dashboard/lib/formatters";
+import { PixelAvatar } from "@/shared/ui/pixel-avatar";
 import { PixelPanel } from "@/shared/ui/pixel-panel";
 import { DashboardStatRow } from "@/widgets/dashboard-skin/ui/dashboard-stat-row";
 import type { CharacterStatSummary } from "@/features/character-summary/lib/build-character-overview";
@@ -98,13 +99,12 @@ export function InventoryCharacterPanel({
   return (
     <PixelPanel title={t("dashboard.panels.summary")} className="h-full">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
-        <div className="pixel-avatar w-fit">
-          <img
-            src={avatarUrl ?? MISSING_SPRITE}
-            alt={t("dashboard.summaryRows.avatar")}
-            className="h-16 w-16 object-contain"
-          />
-        </div>
+        <PixelAvatar
+          src={avatarUrl ?? MISSING_SPRITE}
+          alt={t("dashboard.summaryRows.avatar")}
+          className="w-fit"
+          imageClassName="h-16 w-16 object-contain"
+        />
         <div className="flex-1 space-y-2">
           {rows.map((row) => (
             <div

--- a/src/widgets/ranking-table/ui/ranking-table.tsx
+++ b/src/widgets/ranking-table/ui/ranking-table.tsx
@@ -5,6 +5,7 @@ import {
   PixelSkeletonState,
 } from "@/shared/ui/pixel-state";
 import { PixelPanel } from "@/shared/ui/pixel-panel";
+import { PixelAvatar } from "@/shared/ui/pixel-avatar";
 import type { RankingEntry } from "@/entities/ranking/model/types";
 import { useTranslation } from "react-i18next";
 import type { RankingListState } from "@/features/ranking-list/model/use-ranking-list";
@@ -114,18 +115,13 @@ function RankingRow({ entry }: { entry: RankingEntry }) {
       <td className="text-foreground py-3 pr-2 font-semibold">{entry.rank}</td>
       <td className="py-3">
         <div className="flex items-center gap-3">
-          <div className="pixel-avatar h-10 w-10 p-0">
-            {avatarUrl ? (
-              <img
-                src={avatarUrl}
-                alt={t("ranking.avatarAlt")}
-                className="h-full w-full object-cover"
-                loading="lazy"
-              />
-            ) : (
-              <span className="text-muted-foreground text-xs">—</span>
-            )}
-          </div>
+          <PixelAvatar
+            src={avatarUrl}
+            alt={t("ranking.avatarAlt")}
+            className="h-10 w-10 p-0"
+            imageClassName="h-full w-full object-cover"
+            fallback={<span className="text-muted-foreground text-xs">—</span>}
+          />
           <span className="text-foreground min-w-0 truncate font-medium">
             {displayName}
           </span>

--- a/src/widgets/settings-profile/ui/settings-profile-section.tsx
+++ b/src/widgets/settings-profile/ui/settings-profile-section.tsx
@@ -1,7 +1,7 @@
-import { RefreshCw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useProfile } from "@/entities/profile/model/use-profile";
 import { PixelButton } from "@/shared/ui/pixel-button";
+import { PixelIcon } from "@/shared/ui/pixel-icon";
 import { PixelPanel } from "@/shared/ui/pixel-panel";
 import { PixelSkeleton } from "@/shared/ui/pixel-skeleton";
 import { SettingsProfileCard } from "@/widgets/settings-profile/ui/settings-profile-card";
@@ -40,7 +40,7 @@ export function SettingsProfileSection() {
           pixelSize="compact"
           onClick={() => void profileQuery.refetch()}
         >
-          <RefreshCw className="size-4" aria-hidden />
+          <PixelIcon name="refresh" size={16} className="shrink-0" />
           {t("settings.profile.retry")}
         </PixelButton>
       </PixelPanel>


### PR DESCRIPTION
## 개요

픽셀 UI 톤 일관성을 위해 중복 구현된 UI(아바타/프로그레스/새로고침 아이콘)를 공통 컴포넌트로 정리하고,
대시보드/배너에서 누락된 정보(보너스 스탯, 레벨업 배너 아이콘)를 보완합니다.

## 변경 사항

- `PixelAvatar` 도입 + `.pixel-avatar`를 clip-path 기반 픽셀 프레임 룩으로 통일
- 설정/대시보드/랭킹/인벤토리 아바타를 `PixelAvatar`로 교체
- `PixelProgress` 도입 + 대시보드 StatBar를 공통 컴포넌트 기반으로 정리
- 새로고침 아이콘을 `PixelIcon(name="refresh")`로 단일화
- 대시보드 능력치에 장비 보너스 `(+n)` 표기 추가
- 레벨업 배너에 아이콘 추가 + `levelUp.banner.iconAlt` i18n 키 추가

## 테스트

- [x] `pnpm -C git-dungeon-fe typecheck`
- [x] `pnpm -C git-dungeon-fe test`
- [x] `pnpm -C git-dungeon-fe build-storybook`

### 실행 결과

- 명령어: `pnpm -C git-dungeon-fe typecheck`
- 결과: PASS
- 명령어: `pnpm -C git-dungeon-fe test`
- 결과: PASS (45 files / 170 tests)
- 명령어: `pnpm -C git-dungeon-fe build-storybook`
- 결과: PASS

## 스크린샷

- (사용자 요청) 스크린샷은 본 PR에서 제외합니다.

## 관련 문서

- **Spec**: `docs/features/fe/F048-pixel-ui-consistency/spec.md`
- **Tasks**: `docs/features/fe/F048-pixel-ui-consistency/tasks.md`

Closes #85


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 픽셀 스타일의 아바타(PixelAvatar)와 진행률 바(PixelProgress) 컴포넌트 추가
  * 장비 보너스가 함께 표시되는 능력치 표기(보너스 표시) 추가
  * 레벨업 배너에 아이콘을 노출

* **스타일**
  * 아바타 모양·그림자 및 픽셀 테마 전반 적용
  * 새로고침 아이콘을 픽셀 스타일로 교체

* **문서(스토리북)**
  * 아바타·진행률 컴포넌트용 스토리 추가

* **지역화**
  * 레벨업 아이콘 대체 텍스트 영·한 번역 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->